### PR TITLE
Properly instantiate ListView

### DIFF
--- a/gourmet/gtk_extras/pageable_store.py
+++ b/gourmet/gtk_extras/pageable_store.py
@@ -41,7 +41,7 @@ class PageableListStore (Gtk.ListStore):
         #GObject.GObject.__init__(self,*types)
         # self.__gobject_init__()
         # GObject.GObject.__init__(self, *types)
-        GObject.GObject.__init__(self)
+        Gtk.ListStore.__init__(self, *types)
         self.per_page = per_page
         self._setup_parent_(*parent_args,**parent_kwargs)
         # self.grab_items()


### PR DESCRIPTION
This solves #4 

I probably commented out a few more of those kinds of instantiations. As per https://python-gtk-3-tutorial.readthedocs.io/en/latest/objects.html#inherit-from-gobject-gobject, the proper superclass `__init__` needs to be called.