### PR TITLE
use key function for sorting in seconds_to_timestring

### DIFF
--- a/gourmet/convert.py
+++ b/gourmet/convert.py
@@ -570,7 +570,7 @@ def seconds_to_timestring (time, round_at=None, fractions=FRACTIONS_NORMAL):
     time = int(time)
     time_strings = []
     units = list(Converter.unit_to_seconds.items())
-    units.sort(lambda a,b: a[1]<b[1] and 1 or a[1]>b[1] and -1 or 0)
+    units.sort(key=lambda x: x[1]) #old cmp-func: lambda a,b: a[1]<b[1] and 1 or a[1]>b[1] and -1 or 0
     for unit,divisor in units:
         time_covered = time / int(divisor)
         # special case hours, which we English speakers anyway are


### PR DESCRIPTION
Fixes #7 

I think it is correct this way round. Maybe it needs to be reversed. I kept the old function as a comment