### PR TITLE
Change string.join() pattern to ''.join(); small PEP8 W605 fixes

### DIFF
--- a/gourmet/GourmetRecipeManager.py
+++ b/gourmet/GourmetRecipeManager.py
@@ -1255,7 +1255,7 @@ class RecGui (RecIndex, GourmetApplication, ImporterExporter, StuffThatShouldBeP
         self.set_reccount()
         if hasattr(self,'recTrash'):
             self.recTrash.update_from_db()
-        self.message(_("Deleted") + ' ' + ', '.join([(r.title or _('Untitled')) for r in recs]))
+        self.message(_("Deleted") + ' ' + ', '.join((r.title or _('Untitled')) for r in recs))
 
     def purge_rec_tree (self, recs, paths=None, model=None):
         if not recs:

--- a/gourmet/GourmetRecipeManager.py
+++ b/gourmet/GourmetRecipeManager.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import os.path, os, re, threading, string
+import os.path, os, re, threading
 try:
     from gi import gicompat
 except ImportError:
@@ -1255,7 +1255,7 @@ class RecGui (RecIndex, GourmetApplication, ImporterExporter, StuffThatShouldBeP
         self.set_reccount()
         if hasattr(self,'recTrash'):
             self.recTrash.update_from_db()
-        self.message(_("Deleted") + ' ' + string.join([(r.title or _('Untitled')) for r in recs],', '))
+        self.message(_("Deleted") + ' ' + ', '.join([(r.title or _('Untitled')) for r in recs]))
 
     def purge_rec_tree (self, recs, paths=None, model=None):
         if not recs:

--- a/gourmet/importers/plaintext_importer.py
+++ b/gourmet/importers/plaintext_importer.py
@@ -58,7 +58,7 @@ class TextImporter (importer.Importer):
             # then we have paragraph markers in the text already
             outblob = " ".join(blob.split("\n")) # get rid of line breaks
             lines = outblob.split("") # split text up into paragraphs
-            outblob = "\n".join(lines) # insert linebreaks where paragraphs where
+            outblob = "\n".join(lines) # insert linebreaks where paragraphs were
             return outblob
         outblob = ""
         newline = True

--- a/gourmet/importers/plaintext_importer.py
+++ b/gourmet/importers/plaintext_importer.py
@@ -3,7 +3,7 @@ from gourmet import check_encodings
 from gourmet.gdebug import debug
 from gettext import gettext as _
 
-import re, string
+import re
 
 class TextImporter (importer.Importer):
     ATTR_DICT = {'Recipe By':'source',
@@ -45,32 +45,32 @@ class TextImporter (importer.Importer):
         raise NotImplementedError
 
     def compile_regexps (self):
-        self.blank_matcher = re.compile("^\s*$")
+        self.blank_matcher = re.compile(r"^\s*$")
         # out unwrap regexp looks for a line with no meaningful characters, or a line that starts in
         # ALLCAPS or a line that is only space. (we use this with .split() to break text up into
         # paragraph breaks.
-        self.unwrap_matcher = re.compile('\n\W*\n')
-        self.find_header_breaks_matcher = re.compile('\s+(?=[A-Z][A-Z][A-Z]+:.*)')
+        self.unwrap_matcher = re.compile(r'\n\W*\n')
+        self.find_header_breaks_matcher = re.compile(r'\s+(?=[A-Z][A-Z][A-Z]+:.*)')
 
     def unwrap_lines (self, blob):
         if blob.find("") >= 0:
             debug('Using built-in paragraph markers',1)
             # then we have paragraph markers in the text already
-            outblob = string.join(blob.split("\n")," ") # get rid of line breaks
+            outblob = " ".join(blob.split("\n")) # get rid of line breaks
             lines = outblob.split("") # split text up into paragraphs
-            outblob = string.join(lines,"\n") # insert linebreaks where paragraphs where
+            outblob = "\n".join(lines) # insert linebreaks where paragraphs where
             return outblob
         outblob = ""
         newline = True
         for l in blob.split('\n'):
             debug('examining %s'%l,3)
-            if re.match('^\W*$',l):
+            if re.match(r'^\W*$',l):
                 # ignore repeated nonword characters (hyphens, stars, etc.)
                 outblob += "\n"
                 continue
             # if we have a non-word character at the start of the line,
             # we assume we need to keep the newline.
-            if len(l)>=3 and re.match('(\W|[0-9])',l[2]):
+            if len(l)>=3 and re.match(r'(\W|[0-9])',l[2]):
                 debug('Match non-word character; add newline before: %s'%l,4)
                 outblob += "\n"
                 outblob += l

--- a/gourmet/keymanager.py
+++ b/gourmet/keymanager.py
@@ -58,7 +58,7 @@ class KeyManager(Exception):
         """Return a regexp to match any of the words in string."""
         regexp=r"(^|\W)("
         count=0
-        for w in re.split(r"\W+",txt):
+        for w in self.word_splitter.split(txt):
             #for each keyword, we create a search term
             if w: #no blank strings!
                 count += 1

--- a/gourmet/keymanager.py
+++ b/gourmet/keymanager.py
@@ -1,9 +1,9 @@
-import string, re, time, sys
+import re, time, sys
 from .defaults.defaults import lang as defaults
 from .defaults.defaults import langProperties as langProperties
 from .gdebug import debug, TimeAction
 
-note_separator_regexp = '(;|\s+-\s+|--)'
+note_separator_regexp = r'(;|\s+-\s+|--)'
 note_separator_matcher = re.compile(note_separator_regexp)
 
 def snip_notes (s):
@@ -16,7 +16,7 @@ def snip_notes (s):
 class KeyManager(Exception):
 
     MAX_MATCHES = 10
-    word_splitter = re.compile('\W+')
+    word_splitter = re.compile(r'\W+')
 
     __single = None
 
@@ -56,9 +56,9 @@ class KeyManager(Exception):
 
     def regexp_for_all_words (self, txt):
         """Return a regexp to match any of the words in string."""
-        regexp="(^|\W)("
+        regexp=r"(^|\W)("
         count=0
-        for w in re.split("\W+",txt):
+        for w in re.split(r"\W+",txt):
             #for each keyword, we create a search term
             if w: #no blank strings!
                 count += 1
@@ -226,7 +226,7 @@ class KeyManager(Exception):
             words = ingr.split()
             if len(words) >= 2:
                 if self.cats.__contains__(words[-1]):
-                    ingr = "%s, %s" %(words[-1],string.join(words[0:-1]))
+                    ingr = "%s, %s" %(words[-1],''.join(words[0:-1]))
         #if len(str) > 32:
         #    str = str[0:32]
         debug("End generate_key",10)
@@ -247,7 +247,7 @@ class KeyManager(Exception):
         stringp=True
         if type(words)==type([]):
             stringp=False
-            words = string.join(words," ")
+            words = " ".join(words)
         words = words.split(';')[0] #we ignore everything after semicolon
         words = words.split("--")[0] # we ignore everything after double dashes too!
         m = self.ignored_regexp.match(words)

--- a/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_plaintext_importer.py
+++ b/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_plaintext_importer.py
@@ -1,5 +1,5 @@
 from gourmet.importers import importer, plaintext_importer
-import re, string
+import re
 from gourmet import check_encodings
 from gourmet.gdebug import debug
 from gettext import gettext as _
@@ -28,23 +28,23 @@ class MastercookPlaintextImporter (plaintext_importer.TextImporter):
     def compile_regexps (self):
         plaintext_importer.TextImporter.compile_regexps(self)
         self.rec_start_matcher = re.compile(MASTERCOOK_START_REGEXP)
-        self.blank_matcher = re.compile("^\s*$")
+        self.blank_matcher = re.compile(r"^\s*$")
         # strange thing has happened -- some archives have the column
         # off by exactly 1 character, resulting in some fubar'ing of
         # our parsing.  to solve our problem, we first recognize
         # rec_col_matcher, then parse fields using the ------
         # underlining, which appears to line up even in fubared
         # archives.
-        self.rec_col_matcher = re.compile("(\s*Amount\s*)(Measure\s*)(Ingredient.*)")
-        self.rec_col_underline_matcher = re.compile("(\s*-+)(\s*-+)(\s*-+.*)")
+        self.rec_col_matcher = re.compile(r"(\s*Amount\s*)(Measure\s*)(Ingredient.*)")
+        self.rec_col_underline_matcher = re.compile(r"(\s*-+)(\s*-+)(\s*-+.*)")
         # match a string enclosed in a possibly repeated non-word character
         # such as *Group* or ---group--- or =======GROUP======
         # grabbing groups()[1] will get you the enclosed string
-        self.dash_matcher = re.compile("^[ -]*[-][- ]*$")
-        self.ing_or_matcher = re.compile("\W*[Oo][Rr]\W*")
-        self.ing_group_matcher = re.compile("\s*(\W)\\1*(.+?)(\\1+)")
-        self.mods_matcher = re.compile("^\s*NOTES\.*")
-        attr_matcher = "\s*(" + string.join(list(self.ATTR_DICT.keys()),"|") + ")\s*:(.*)"
+        self.dash_matcher = re.compile(r"^[ -]*[-][- ]*$")
+        self.ing_or_matcher = re.compile(r"\W*[Oo][Rr]\W*")
+        self.ing_group_matcher = re.compile(r"\s*(\W)\\1*(.+?)(\\1+)")
+        self.mods_matcher = re.compile(r"^\s*NOTES\.*")
+        attr_matcher = fr"\s*({'|'.join(list(self.ATTR_DICT.keys()))})\s*:(.*)"
         self.attr_matcher = re.compile(attr_matcher)
 
     def handle_line (self, line):

--- a/gourmet/plugins/nutritional_information/databaseGrabber.py
+++ b/gourmet/plugins/nutritional_information/databaseGrabber.py
@@ -1,5 +1,5 @@
 import sys
-import urllib.request, urllib.parse, urllib.error, zipfile, tempfile, os.path, re, string
+import urllib.request, urllib.parse, urllib.error, zipfile, tempfile, os.path, re
 from gettext import gettext as _
 from .parser_data import ABBREVS, ABBREVS_STRT, FOOD_GROUPS, NUTRITION_FIELDS, WEIGHT_FIELDS
 from gourmet.gdebug import TimeAction
@@ -7,7 +7,7 @@ expander_regexp = None
 
 def compile_expander_regexp ():
     regexp = "(?<!\w)("
-    regexp += string.join(list(ABBREVS.keys()),"|")
+    regexp += "|".join(list(ABBREVS.keys()))
     regexp += ")(?!\w)"
     return re.compile(regexp)
 

--- a/gourmet/reccard.py
+++ b/gourmet/reccard.py
@@ -2526,9 +2526,9 @@ class IngredientTreeUI:
         strings=[]
         iters=[]
         tv.get_selection().selected_foreach(grab_selection,(strings,iters))
-        _str="\n".join(strings)
-        selection.set('text/plain',0,_str)
-        selection.set('STRING',0,_str)
+        ingredients="\n".join(strings)
+        selection.set('text/plain',0,ingredients)
+        selection.set('STRING',0,ingredients)
         selection.set('GOURMET_INTERNAL',8,'blarg')
         self.selected_iter=iters
 

--- a/gourmet/reccard.py
+++ b/gourmet/reccard.py
@@ -4,7 +4,7 @@ import gi
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
-import os.path, string
+import os.path
 try:
     from PIL import Image
 except ImportError:
@@ -2526,9 +2526,9 @@ class IngredientTreeUI:
         strings=[]
         iters=[]
         tv.get_selection().selected_foreach(grab_selection,(strings,iters))
-        str=string.join(strings,"\n")
-        selection.set('text/plain',0,str)
-        selection.set('STRING',0,str)
+        _str="\n".join(strings)
+        selection.set('text/plain',0,_str)
+        selection.set('STRING',0,_str)
         selection.set('GOURMET_INTERNAL',8,'blarg')
         self.selected_iter=iters
 


### PR DESCRIPTION
The main purpose of this simple change is to remove obsolete pattern:
```python
string.join(some_list, 'sep')  ==> sep.join(some_list)
```

In all cases after that change we can remove unnecessary `string` import.

I also changed some strings that trigger W605 Flake warning.