### PR TITLE
Do not try to decode strings

### DIFF
--- a/gourmet/backends/db.py
+++ b/gourmet/backends/db.py
@@ -1867,8 +1867,9 @@ class RecipeManager (RecData):
         debug('ingredient_parser handed: %s'%s,0)
         # Strip whitespace and bullets...
         d={}
-        s = s.decode('utf8').strip(
-            '\u2022\u2023\u2043\u204C\u204D\u2219\u25C9\u25D8\u25E6\u2619\u2765\u2767\u29BE\u29BF\n\t #*+-')
+        if isinstance(s, bytes):
+            s = s.decode('utf8').strip(
+                '\u2022\u2023\u2043\u204C\u204D\u2219\u25C9\u25D8\u25E6\u2619\u2765\u2767\u29BE\u29BF\n\t #*+-')
         option_m = re.match('\s*optional:?\s*',s,re.IGNORECASE)
         if option_m:
             s = s[option_m.end():]

--- a/gourmet/backends/db.py
+++ b/gourmet/backends/db.py
@@ -1868,7 +1868,8 @@ class RecipeManager (RecData):
         # Strip whitespace and bullets...
         d={}
         if isinstance(s, bytes):
-            s = s.decode('utf8').strip(
+            s = s.decode('utf8')
+        s = s.strip(
                 '\u2022\u2023\u2043\u204C\u204D\u2219\u25C9\u25D8\u25E6\u2619\u2765\u2767\u29BE\u29BF\n\t #*+-')
         option_m = re.match('\s*optional:?\s*',s,re.IGNORECASE)
         if option_m:

--- a/gourmet/gtk_extras/TextBufferMarkup.py
+++ b/gourmet/gtk_extras/TextBufferMarkup.py
@@ -181,7 +181,8 @@ class PangoBuffer (Gtk.TextBuffer):
         tagdict=self.get_tags()
         if not start: start=self.get_start_iter()
         if not end: end=self.get_end_iter()
-        txt = str(Gtk.TextBuffer.get_text(self,start,end))
+        txt = Gtk.TextBuffer.get_text(self, start, end,
+                                      include_hidden_chars=False)
         cuts = {}
         for k,v in list(tagdict.items()):
             if k not in self.tagdict: continue

--- a/gourmet/gtk_extras/dialog_extras.py
+++ b/gourmet/gtk_extras/dialog_extras.py
@@ -67,7 +67,7 @@ class ModalDialog (Gtk.Dialog):
         self.label = Gtk.Label(label=label)
         self.label.set_line_wrap(True)
         self.label.set_selectable(True)
-        self.vbox.pack_start(self.label,expand=False)
+        self.vbox.pack_start(self.label, expand=False, fill=False, padding=0)
         self.label.set_padding(H_PADDING,Y_PADDING)
         self.label.set_alignment(0,0)
         self.label.set_justify(Gtk.Justification.LEFT)

--- a/gourmet/reccard.py
+++ b/gourmet/reccard.py
@@ -1457,7 +1457,7 @@ class DescriptionEditorModule (TextEditor, RecEditorModule):
 
     def save (self, recdic):
         for c in self.reccom:
-            recdic[c]=str(self.rw[c].entry.get_text())
+            recdic[c]=str(self.rw[c].get_active_text())
         for e in self.recent:
             if e in INT_REC_ATTRS +  FLOAT_REC_ATTRS:
                 recdic[e]=self.rw[e].get_value()


### PR DESCRIPTION
These are two little changes.

It turns out that `gourmet/backend/db.py` does manipulation of inputs coming both from the db (where it's dealt `bytes`), and from the GUI (where the types are `str`). I guess there will be more checks like these needed in that file.

In `gourmet/gtk_extra/dialog_extra.py`, the `ModalDialog.vbox` constructor API has changed in Gtk3.
I'm considering also doing a project-wide fix, as was done earlier for the various `sort` calls in #50.

The cool thing with these two little changes, along with #48, is that now crashes happen within the tests I'm fixing (#32). 
Sure the origins of the errors in these tests come from deep-down, but the instantiation of a `RecCard` is now fixed :)