### PR TITLE
Fix application start on Windows

### DIFF
--- a/gourmet/Undo.py
+++ b/gourmet/Undo.py
@@ -1,4 +1,6 @@
 import difflib, re
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from gourmet.gdebug import debug

--- a/gourmet/gglobals.py
+++ b/gourmet/gglobals.py
@@ -19,7 +19,7 @@ else:
         # http://stackoverflow.com/questions/2608200/problems-with-umlauts-in-python-appdata-environvent-variable
         # We might drop this workaround with Python 3 (all strings are unicode)
         # and/or GTK+ 3 (use Glib.get_home_dir()).
-        APPDATA = windows.getenv('APPDATA').decode('utf-8')
+        APPDATA = windows.getenv('APPDATA')
         gourmetdir = os.path.join(APPDATA,'gourmet')
     else:
         gourmetdir = os.path.join(os.path.expanduser('~'),'.gourmet')


### PR DESCRIPTION
This fixes the start for Windows systems by removing the call to `decode`. Otherwise running the web import parser tests fails as well (this is where I stumbled upon this).

Additionally I fixed a warning showing up when running the parser tests which is related to the missing Gtk version initialization in `Undo.py`.