### PR TITLE
Fix syntax error in nutritionDisplay

### DIFF
--- a/gourmet/plugins/nutritional_information/nutritionDisplay.py
+++ b/gourmet/plugins/nutritional_information/nutritionDisplay.py
@@ -168,8 +168,8 @@ if __name__ == '__main__':
         Gtk.mainquit()
     #snd=SimpleNutritionalDisplay(db.nutrition_table)
     #snd.w.connect('delete-event',quit)
-    from . import nutrition.nutrition
-    nd=nutrition.nutrition.NutritionData(db,conv)
+    from . import nutrition
+    nd=nutrition.NutritionData(db,conv)
     sic = SimpleIngredientCalculator(nd,umod)
     sic.run()
     Gtk.main()


### PR DESCRIPTION
I currently can't start the plugin window to look at the nutrition display, but this is a syntax error that prevents me from running mypy.