### PR TITLE
Clean up singleton classes - second attempt

### DIFF
--- a/gourmet/GourmetRecipeManager.py
+++ b/gourmet/GourmetRecipeManager.py
@@ -737,13 +737,13 @@ class ImporterExporter:
             change_units=self.prefs.get('readableUnits',True)
             )
 
-    _import_manager = None
+    __import_manager = None
 
     @property
     def importManager(self):
-        if self._import_manager is None:
-            self._import_manager = get_import_manager()
-        return self._import_manager
+        if self.__import_manager is None:
+            self.__import_manager = get_import_manager()
+        return self.__import_manager
 
     def import_webpageg (self, *args):
         self.importManager.offer_web_import(parent=self.app.get_toplevel())
@@ -751,13 +751,13 @@ class ImporterExporter:
     def do_import (self, *args):
         self.importManager.offer_import(self.window)
 
-    _export_manager = None
+    __export_manager = None
 
     @property
     def exportManager(self):
-        if self._export_manager is None:
-            self._export_manager = get_export_manager()
-        return self._export_manager
+        if self.__export_manager is None:
+            self.__export_manager = get_export_manager()
+        return self.__export_manager
 
     def do_export (self, export_all=False):
         if export_all:

--- a/gourmet/GourmetRecipeManager.py
+++ b/gourmet/GourmetRecipeManager.py
@@ -88,8 +88,6 @@ class GourmetApplication:
         self.setup_shopping()
         self.setup_go_menu()
         self.rc={}
-        self.exportManager = get_export_manager()
-        self.importManager = get_import_manager()
 
     def setup_plugins (self):
         pass
@@ -739,15 +737,29 @@ class ImporterExporter:
             change_units=self.prefs.get('readableUnits',True)
             )
 
+    _import_manager = None
+
+    @property
+    def importManager(self):
+        if self._import_manager is None:
+            self._import_manager = get_import_manager()
+        return self._import_manager
+
     def import_webpageg (self, *args):
         self.importManager.offer_web_import(parent=self.app.get_toplevel())
 
     def do_import (self, *args):
         self.importManager.offer_import(self.window)
 
+    _export_manager = None
+
+    @property
+    def exportManager(self):
+        if self._export_manager is None:
+            self._export_manager = get_export_manager()
+        return self._export_manager
+
     def do_export (self, export_all=False):
-        if not hasattr(self,'exportManager'):
-            self.exportManager = get_export_manager()
         if export_all:
             recs = self.rd.fetch_all(self.rd.recipe_table,deleted=False,sort_by=[('title',1)])
         else:

--- a/gourmet/GourmetRecipeManager.py
+++ b/gourmet/GourmetRecipeManager.py
@@ -67,10 +67,14 @@ class GourmetApplication:
 
     __single = None
 
+    @classmethod
+    def instance(cls):
+        if GourmetApplication.__single is None:
+            GourmetApplication.__single = cls()
+
+        return GourmetApplication.__single
+
     def __init__ (self, splash_label=None):
-        if GourmetApplication.__single:
-            raise GourmetApplication.__single
-        GourmetApplication.__single = self
         # These first two items might be better handled using a
         # singleton design pattern...
         self.splash_label = splash_label
@@ -904,11 +908,14 @@ class RecGui (RecIndex, GourmetApplication, ImporterExporter, StuffThatShouldBeP
 
     __single = None
 
+    @classmethod
+    def instance(cls):
+        if RecGui.__single is None:
+            RecGui.__single = cls()
+
+        return RecGui.__single
+
     def __init__ (self, splash_label=None):
-        if RecGui.__single:
-            raise RecGui.__single
-        else:
-            RecGui.__single = self
         self.doing_multiple_deletions = False
         GourmetApplication.__init__(self, splash_label=splash_label)
         self.setup_index_columns()
@@ -1401,10 +1408,7 @@ class RecGui (RecIndex, GourmetApplication, ImporterExporter, StuffThatShouldBeP
         Gtk.main_quit()
 
 def get_application ():
-    try:
-        return RecGui()
-    except RecGui as rg:
-        return rg
+    return RecGui.instance()
 
 if __name__ == '__main__':
     if os.name!='nt':

--- a/gourmet/convert.py
+++ b/gourmet/convert.py
@@ -66,9 +66,16 @@ class PossiblyCaseInsensitiveDictionary(collections.abc.MutableMapping):
         self.__mapping[norm] = value
 
 
-class Converter(BaseException):
+class Converter:
 
     __single = None
+
+    @classmethod
+    def instance(cls):
+        if Converter.__single is None:
+            Converter.__single = cls()
+
+        return Converter.__single
 
     unit_to_seconds = {
     'seconds':1,
@@ -104,8 +111,6 @@ class Converter(BaseException):
                   ]
 
     def __init__(self):
-        if Converter.__single: raise Converter.__single
-        else: Converter.__single = self
         self.create_conv_table()
         self.create_density_table()
         self.create_cross_unit_table()
@@ -576,10 +581,7 @@ class Converter(BaseException):
         if seconds: return seconds
 
 def get_converter ():
-    try:
-        return Converter()
-    except Converter as c:
-        return c
+    return Converter.instance()
 
 # Each of our time formatting functions takes two arguments, which
 # allows us to handle fractions in the outside world

--- a/gourmet/exporters/exportManager.py
+++ b/gourmet/exporters/exportManager.py
@@ -16,9 +16,14 @@ class ExportManager (plugin_loader.Pluggable):
 
     __single = None
 
+    @classmethod
+    def instance(cls):
+        if not ExportManager.__single:
+            ExportManager.__single = ExportManager()
+
+        return ExportManager.__single
+
     def __init__ (self):
-        if ExportManager.__single: raise ExportManager.__single
-        else: ExportManager.__single = self
         self.plugins_by_name = {}
         plugin_loader.Pluggable.__init__(self,
                                          [ExporterPlugin]
@@ -193,7 +198,4 @@ class ExportManager (plugin_loader.Pluggable):
             print('WARNING: unregistering ',plugin,'but there seems to be no plugin for ',name)
 
 def get_export_manager ():
-    try:
-        return ExportManager()
-    except ExportManager as em:
-        return em
+    return ExportManager.instance()

--- a/gourmet/exporters/printer.py
+++ b/gourmet/exporters/printer.py
@@ -28,11 +28,14 @@ class PrintManager (plugin_loader.Pluggable):
 
     __single = None
 
+    @classmethod
+    def instance(cls):
+        if not PrintManager.__single:
+            PrintManager.__single = PrintManager()
+
+        return PrintManager.__single
+
     def __init__ (self):
-        if PrintManager.__single:
-            raise PrintManager.__single
-        else:
-            PrintManager.__single = self
         self.sws = [(-1,NoSimpleWriter)]
         self.rrs = [(-1,NoRecRenderer)]
         plugin_loader.Pluggable.__init__(self,
@@ -85,9 +88,6 @@ class PrintManager (plugin_loader.Pluggable):
         show_message(sublabel='There was an error printing. Apologies')
 
 def get_print_manager ():
-    try:
-        return PrintManager()
-    except PrintManager as pm:
-        return pm
+    return PrintManager.instance()
 
 #printManager = get_print_manager()

--- a/gourmet/importers/importManager.py
+++ b/gourmet/importers/importManager.py
@@ -26,9 +26,14 @@ class ImportManager (plugin_loader.Pluggable):
 
     __single = None
 
+    @classmethod
+    def instance(cls):
+        if ImportManager.__single is None:
+            ImportManager.__single = cls()
+
+        return ImportManager.__single
+
     def __init__ (self):
-        if ImportManager.__single: raise ImportManager.__single
-        else: ImportManager.__single = self
         self.tempfiles = {}
         self.extensions_by_mimetype = {}
         self.plugins_by_name = {}
@@ -278,12 +283,9 @@ class ImportManager (plugin_loader.Pluggable):
             self.plugins.remove(plugin)
 
 def get_import_manager ():
-    try:
-        return ImportManager()
-    except ImportManager as im:
-        return im
+    return ImportManager.instance()
 
 if __name__ == '__main__':
-    im = ImportManager()
+    im = ImportManager.instance()
     im.offer_import()
     Gtk.main()

--- a/gourmet/keymanager.py
+++ b/gourmet/keymanager.py
@@ -17,18 +17,21 @@ def snip_notes (s):
     if ret: return ret
     else: return s
 
-class KeyManager(Exception):
+class KeyManager:
 
     MAX_MATCHES = 10
     word_splitter = re.compile(r'\W+')
 
     __single = None
 
+    @classmethod
+    def instance(cls, *args, **kwargs):
+        if KeyManager.__single is None:
+            KeyManager.__single = cls(*args, **kwargs)
+
+        return KeyManager.__single
+
     def __init__ (self, kd={}, rm=None):
-        if KeyManager.__single:
-            raise KeyManager.__single
-        else:
-            KeyManager.__single = self
         self.kd = kd
         if not rm:
             from . import recipeManager
@@ -338,10 +341,7 @@ cooking_verbs=["cored",
                "chilled"]
 
 def get_keymanager (*args, **kwargs):
-    try:
-        return KeyManager(*args,**kwargs)
-    except KeyManager as km:
-        return km
+    return KeyManager.instance(*args,**kwargs)
 
 if __name__ == '__main__':
 

--- a/gourmet/plugin_loader.py
+++ b/gourmet/plugin_loader.py
@@ -20,7 +20,7 @@ except:
 # pointing to the module (with the module parameter) and giving the
 # name and comment for the plugin.
 
-class MasterLoader(BaseException):
+class MasterLoader:
 
     # Singleton design pattern lifted from:
     # http://www.python.org/workshops/1997-10/proceedings/savikko.html
@@ -48,10 +48,14 @@ class MasterLoader(BaseException):
         ]
     active_plugin_filename = os.path.join(gglobals.gourmetdir,'active_plugins')
 
+    @classmethod
+    def instance(cls):
+        if MasterLoader.__single is None:
+            MasterLoader.__single = MasterLoader()
+
+        return MasterLoader.__single
+
     def __init__ (self):
-        if MasterLoader.__single:
-            raise MasterLoader.__single
-        MasterLoader.__single = self
         self.plugin_directories = [os.path.join(gglobals.gourmetdir,'plugins'), # user plug-ins
                                    os.path.join(current_path,'plugins'), # pre-installed plugins
                                    os.path.join(current_path,'plugins','import_export'), # pre-installed exporter plugins
@@ -215,12 +219,7 @@ class MasterLoader(BaseException):
         self.pluggables_by_class[klass].remove(pluggable)
 
 def get_master_loader ():
-    # Singleton design pattern lifted from:
-    # http://www.python.org/workshops/1997-10/proceedings/savikko.html
-    try:
-        return MasterLoader()
-    except MasterLoader as ml:
-        return ml
+    return MasterLoader.instance()
 
 class PluginSet:
     """A lazy-loading set of plugins.

--- a/gourmet/plugins/key_editor/keyEditorPluggable.py
+++ b/gourmet/plugins/key_editor/keyEditorPluggable.py
@@ -71,11 +71,14 @@ class KeyEditorPluginManager (Pluggable):
 
     __single = None
 
+    @classmethod
+    def instance(cls):
+        if KeyEditorPluginManager.__single is None:
+            KeyEditorPluginManager.__single = cls()
+
+        return KeyEditorPluginManager.__single
+
     def __init__ (self):
-        if not KeyEditorPluginManager.__single:
-            KeyEditorPluginManager.__single = self
-        else:
-            raise KeyEditorPluginManager.__single
         Pluggable.__init__(self,[PluginPlugin])
 
     def get_treeview_columns (self, ike, key_col, instant_apply=False):
@@ -93,7 +96,4 @@ class KeyEditorPluginManager (Pluggable):
         return buttons
 
 def get_key_editor_plugin_manager ():
-    try:
-        return KeyEditorPluginManager()
-    except KeyEditorPluginManager as kepm:
-        return kepm
+    return KeyEditorPluginManager.instance()

--- a/gourmet/prefs.py
+++ b/gourmet/prefs.py
@@ -1,9 +1,16 @@
 import os, os.path, pickle
 from gourmet import gglobals
 
-class Prefs(BaseException):
+class Prefs:
 
     __single = None
+
+    @classmethod
+    def instance(cls):
+        if Prefs.__single is None:
+            Prefs.__single = cls()
+
+        return Prefs.__single
 
     def __init__ (self, file=os.path.join(gglobals.gourmetdir,'guiprefs')):
         """A basic class for handling preferences.
@@ -16,10 +23,6 @@ class Prefs(BaseException):
         they will be called each time a preference is changed and
         handed the key and value as arguments: hook(key,value).
         """
-        if Prefs.__single:
-            raise Prefs.__single
-        else:
-            Prefs.__single = self
         self.file=file
         self.config = {}
         self.load()
@@ -85,10 +88,7 @@ class Prefs(BaseException):
         return False
 
 def get_prefs ():
-    try:
-        return Prefs()
-    except Prefs as p:
-        return p
+    return Prefs.instance()
 
 if __name__ == '__main__':
     p = Prefs()

--- a/gourmet/tests/test_exportManager.py
+++ b/gourmet/tests/test_exportManager.py
@@ -13,6 +13,13 @@ class SampleRecipeSetterUpper:
 
     __single = None
 
+    @classmethod
+    def instance(cls):
+        if SampleRecipeSetterUpper.__single is None:
+            SampleRecipeSetterUpper.__single = cls()
+
+        return SampleRecipeSetterUpper.__single
+
     recipes = {
         'simple recipe' : {
             'recipe' : {'title':'Simple Test','cuisine':'Indian','instructions':'Cook as usual','modifications':'Unless you want to get fancy',
@@ -55,9 +62,6 @@ class SampleRecipeSetterUpper:
         }
 
     def __init__ (self):
-        print('Instantiate SampleRecipeSetterUpper',self)
-        if SampleRecipeSetterUpper.__single: raise SampleRecipeSetterUpper.__single
-        else: SampleRecipeSetterUpper.__single = self
         self.db = gourmet.backends.db.get_database()
         for rec in self.recipes:
             self.add_rec(self.recipes[rec])
@@ -84,11 +88,8 @@ class SampleRecipeSetterUpper:
         print('^^^^^^^^^^^^^^^^^^^^')
 
 def setup_sample_recs ():
-    try:
-        return SampleRecipeSetterUpper()
-    except SampleRecipeSetterUpper as srsu:
-        print('Returning single...')
-        return srsu
+    return SampleRecipeSetterUpper.instance()
+# FIXME: We're instantiating this class for side effects. Rethink that.
 
 class TestSetterUpper (unittest.TestCase):
      def setUp (self):

--- a/gourmet/tests/test_importers.py
+++ b/gourmet/tests/test_importers.py
@@ -54,11 +54,6 @@ class ThreadlessImportManager (ImportManager):
             importer.run()
             self.follow_up(None,importer)
 
-def get_im ():
-    try:
-        return ThreadlessImportManager()
-    except ThreadlessImportManager as im:
-        return im
 
 class ImportTest:
 
@@ -147,7 +142,7 @@ class ImportTest:
 
     @time_me
     def setup_db (self):
-        self.im = get_im()
+        self.im = ThreadlessImportManager.instance()
         self.db = get_recipe_manager(custom_url='sqlite:///:memory:')
 
     @time_me

--- a/gourmet/threadManager.py
+++ b/gourmet/threadManager.py
@@ -160,9 +160,14 @@ class ThreadManager:
 
     __single = None
 
+    @classmethod
+    def instance(cls):
+        if ThreadManager.__single is None:
+            ThreadManager.__single = cls()
+
+        return ThreadManager.__single
+
     def __init__ (self, max_concurrent_threads = 2):
-        if ThreadManager.__single:
-            raise ThreadManager.__single
         self.max_concurrent_threads = max_concurrent_threads
         self.thread_queue = []
         self.count = 0
@@ -217,22 +222,23 @@ class ThreadManager:
                 thread_to_add.initialize_thread()
 
 def get_thread_manager ():
-    try:
-        return ThreadManager()
-    except ThreadManager as tm:
-        return tm
+    return ThreadManager.instance()
+
 
 class ThreadManagerGui:
 
-    __single__ = None
+    __single = None
     paused_text = ' (' + _('Paused') + ')'
     PAUSE = 10
 
+    @classmethod
+    def instance(cls):
+        if ThreadManagerGui.__single is None:
+            ThreadManagerGui.__single = cls()
+
+        return ThreadManagerGui.__single
+
     def __init__ (self, messagebox=None):
-        if ThreadManagerGui.__single__:
-            raise ThreadManagerGui.__single__
-        else:
-            ThreadManagerGui.__single__ = self
         self.tm = get_thread_manager()
         self.threads = {}
 
@@ -387,10 +393,8 @@ class ThreadManagerGui:
                         )
 
 def get_thread_manager_gui ():
-    try:
-        return ThreadManagerGui()
-    except ThreadManagerGui as tmg:
-        return tmg
+    return ThreadManagerGui.instance()
+
 
 if __name__ == '__main__':
     from gi.repository import Gtk


### PR DESCRIPTION
Follow up from #66 to allow starting the app again. :-)

Break the cycles between the app class and ImportManager/ExportManager by using properties to create the manager instances when they're first used.