### PR TITLE
Fix type-errors in gourmet/defaults

### DIFF
--- a/gourmet/defaults/defaults.py
+++ b/gourmet/defaults/defaults.py
@@ -1,4 +1,4 @@
-import locale, os
+import locale, os, sys
 from typing import Optional
 from .abstractLang import AbstractLanguage
 deflang = 'en'
@@ -14,7 +14,8 @@ if os.name == 'posix':
 
 # Windows locales are named differently, e.g. German_Austria instead of de_AT
 # Fortunately, we can find the POSIX-like type using a different method.
-elif os.name == 'nt':
+# sys.platform is the correct check per mypy convention (https://mypy.readthedocs.io/en/stable/common_issues.html?highlight=platform#python-version-and-system-platform-checks)
+elif sys.platform == "win32":
     from ctypes import windll
     locid = windll.kernel32.GetUserDefaultLangID()
     loc = locale.windows_locale[locid]

--- a/gourmet/defaults/defaults_de.py
+++ b/gourmet/defaults/defaults_de.py
@@ -16,6 +16,7 @@
 # Last-updated: 2005-01-15 (07/18/05)
 
 from .abstractLang import AbstractLanguage
+from typing import Collection, Mapping, Any
 
 class Language(AbstractLanguage):
 
@@ -117,7 +118,7 @@ class Language(AbstractLanguage):
     # nutritional database. For these items, we will have nutritional
     # information by default.
 
-    NUTRITIONAL_INFO = {}
+    NUTRITIONAL_INFO: Mapping[str, Any] = {}
 
     # a dictionary for ambiguous words.
     # key=ambiguous word, value=list of possible non-ambiguous terms
@@ -833,7 +834,7 @@ class Language(AbstractLanguage):
               "dick","dicker","dicke","dickes","dicken"
               ]
 
-    NUMBERS = {
+    NUMBERS: Mapping[float, Collection[str]] = {
         }
 
     # These functions are rather important! Our goal is simply to

--- a/gourmet/defaults/defaults_en.py
+++ b/gourmet/defaults/defaults_en.py
@@ -30,6 +30,7 @@
 # with what users in your locale are likely to be familiar with.
 
 from .abstractLang import AbstractLanguage
+from typing import Any, Mapping, List
 
 class Language(AbstractLanguage):
 
@@ -93,7 +94,7 @@ class Language(AbstractLanguage):
     # nutritional database. For these items, we will have nutritional
     # information by default.
 
-    NUTRITIONAL_INFO = {}
+    NUTRITIONAL_INFO: Mapping[str, Any] = {}
 
     # a dictionary for ambiguous words.
     # key=ambiguous word, value=list of possible non-ambiguous terms
@@ -105,7 +106,7 @@ class Language(AbstractLanguage):
     #              'word':['meaning1','meaning2','meaning3'],
     #             }
 
-    AMBIGUOUS = {}
+    AMBIGUOUS: Mapping[str, List[str]] = {}
 
 
     # triplicates ITEM, KEY, SHOPPING CATEGORY

--- a/gourmet/defaults/defaults_en_GB.py
+++ b/gourmet/defaults/defaults_en_GB.py
@@ -6,6 +6,7 @@
 ## files.
 
 from .abstractLang import AbstractLanguage
+from typing import List, Mapping
 
 class Language(AbstractLanguage):
 
@@ -57,7 +58,7 @@ class Language(AbstractLanguage):
         ]
 
     # a dictionary key=ambiguous word, value=list of terms
-    AMBIGUOUS = {}
+    AMBIGUOUS: Mapping[str, List[str]] = {}
 
 
     # triplicates ITEM, KEY, SHOPPING CATEGORY

--- a/gourmet/defaults/defaults_es.py
+++ b/gourmet/defaults/defaults_es.py
@@ -9,6 +9,7 @@
 # Last-updated: 4/27/05
 
 from .abstractLang import AbstractLanguage
+from typing import Collection, Mapping, List
 
 class Language(AbstractLanguage):
 
@@ -34,7 +35,7 @@ class Language(AbstractLanguage):
         ]
 
     # a dictionary key=ambiguous word, value=list of terms
-    AMBIGUOUS = {}
+    AMBIGUOUS: Mapping[str, List[str]] = {}
 
 
     # triplicates ITEM, KEY, SHOPPING CATEGORY
@@ -444,7 +445,7 @@ class Language(AbstractLanguage):
     def guess_plurals (s):
         return [s+'s',s+'es']
 
-    IGNORE = []
+    IGNORE: Collection[str] = []
 
     NUMBERS = {
         (1.0/8):['octavo','un octavo'],

--- a/gourmet/defaults/defaults_fr.py
+++ b/gourmet/defaults/defaults_fr.py
@@ -16,6 +16,7 @@
 # Last-updated: 2005-07-18 (07/18/05)
 
 from .abstractLang import AbstractLanguage
+from typing import Collection, Mapping
 
 class Language(AbstractLanguage):
 
@@ -1135,5 +1136,5 @@ class Language(AbstractLanguage):
              "chaud","chaude","chauds","chaudes","finement","mince","minces",
              "approximativement","grosso modo","vulgairement"]
 
-    NUMBERS = {
+    NUMBERS: Mapping[float, Collection[str]] = {
         }

--- a/gourmet/defaults/defaults_nl.py
+++ b/gourmet/defaults/defaults_nl.py
@@ -5,6 +5,7 @@
 ## files.
 
 from .abstractLang import AbstractLanguage
+from typing import Collection, List, Mapping
 
 class Language(AbstractLanguage):
 
@@ -28,10 +29,10 @@ class Language(AbstractLanguage):
     # If there are none of these that you can think of in your language, just
     # set this to:
     # SYNONYMS=[]
-    SYNONYMS=[]
+    SYNONYMS: Collection[List[str]] = []
 
     # a dictionary key=ambiguous word, value=list of possible non-ambiguous terms
-    AMBIGUOUS = {}
+    AMBIGUOUS: Mapping[str, List[str]] = {}
 
 
     # triplicates ITEM, KEY, SHOPPING CATEGORY
@@ -434,4 +435,4 @@ class Language(AbstractLanguage):
         """
         return [s+"en",s+"s"]
 
-    IGNORE = []
+    IGNORE: Collection[str] = []

--- a/gourmet/defaults/defaults_pt.py
+++ b/gourmet/defaults/defaults_pt.py
@@ -5,6 +5,7 @@
 ## files.
 
 from .abstractLang import AbstractLanguage
+from typing import Collection, List, Mapping, Tuple
 
 class Language(AbstractLanguage):
 
@@ -29,12 +30,12 @@ class Language(AbstractLanguage):
     # If there are none of these that you can think of in your language, just
     # set this to:
     # SYNONYMS=[]
-    SYNONYMS=[
+    SYNONYMS: Collection[List[str]] = [
         # the first item of each list is the default
         ]
 
     # a dictionary key=ambiguous word, value=list of possible non-ambiguous terms
-    AMBIGUOUS = {}
+    AMBIGUOUS: Mapping[str, List[str]] = {}
 
 
     # triplicates ITEM, KEY, SHOPPING CATEGORY
@@ -42,7 +43,7 @@ class Language(AbstractLanguage):
     # standard for your locale, with whatever sensible default categories
     # you can think of (again, thinking of your locale, not simply translating
     # what I've done).
-    INGREDIENT_DATA = [
+    INGREDIENT_DATA: Collection[Tuple[str, str, str]] = [
                        # fruits, from wikipedia list
                        ## seafood, from wikipedia list
                        ## meats (garnered from wikipedia lists)
@@ -190,7 +191,7 @@ class Language(AbstractLanguage):
 
     def guess_plurals (s): return [s+'s',s+'es']
 
-    IGNORE=[]
+    IGNORE: Collection[str] = []
 
-    NUMBERS = {
+    NUMBERS: Mapping[float, Collection[str]] = {
         }

--- a/gourmet/defaults/defaults_ru.py
+++ b/gourmet/defaults/defaults_ru.py
@@ -17,6 +17,7 @@
 # Last-updated: July 12, 2009
 
 from .abstractLang import AbstractLanguage
+from typing import Mapping, Any, List
 
 class Language(AbstractLanguage):
 
@@ -89,7 +90,7 @@ class Language(AbstractLanguage):
     # nutritional database. For these items, we will have nutritional
     # information by default.
 
-    NUTRITIONAL_INFO = {}
+    NUTRITIONAL_INFO: Mapping[str, Any] = {}
 
     # a dictionary for ambiguous words.
     # key=ambiguous word, value=list of possible non-ambiguous terms
@@ -101,7 +102,7 @@ class Language(AbstractLanguage):
     #              'word':['meaning1','meaning2','meaning3'],
     #             }
 
-    AMBIGUOUS = {}
+    AMBIGUOUS: Mapping[str, List[str]] = {}
 
 
     # triplicates ITEM, KEY, SHOPPING CATEGORY

--- a/gourmet/defaults/defaults_sk.py
+++ b/gourmet/defaults/defaults_sk.py
@@ -5,6 +5,7 @@
 ## files.
 
 from .abstractLang import AbstractLanguage
+from typing import Collection, List, Mapping
 
 class Language(AbstractLanguage):
 
@@ -79,10 +80,10 @@ class Language(AbstractLanguage):
     # for those synonyms.  ["preferred word","alternate word","alternate word"]
     # If there are none of these that you can think of in your language, just
     # set this to:
-    SYNONYMS=[]
+    SYNONYMS: Collection[List[str]] = []
 
     # a dictionary key=ambiguous word, value=list of possible non-ambiguous terms
-    AMBIGUOUS = {}
+    AMBIGUOUS: Mapping[str, List[str]] = {}
 
 
     # triplicates ITEM, KEY, SHOPPING CATEGORY
@@ -532,7 +533,7 @@ class Language(AbstractLanguage):
     def guess_singulars (s): return []
     def guess_plurals (s): return []
 
-    IGNORE=[]
+    IGNORE: Collection[str] = []
 
-    NUMBERS = {
+    NUMBERS: Mapping[float, Collection[str]] = {
         }

--- a/gourmet/defaults/defaults_sv.py
+++ b/gourmet/defaults/defaults_sv.py
@@ -17,6 +17,7 @@
 # Last-updated: 2006-06-28
 
 from .abstractLang import AbstractLanguage
+from typing import List, Mapping, Any
 
 class Language(AbstractLanguage):
 
@@ -64,7 +65,7 @@ class Language(AbstractLanguage):
     # nutritional database. For these items, we will have nutritional
     # information by default.
 
-    NUTRITIONAL_INFO = {}
+    NUTRITIONAL_INFO: Mapping[str, Any] = {}
 
     # a dictionary for ambiguous words.
     # key=ambiguous word, value=list of possible non-ambiguous terms
@@ -76,7 +77,7 @@ class Language(AbstractLanguage):
     #              'word':['meaning1','meaning2','meaning3'],
     #             }
 
-    AMBIGUOUS = {}
+    AMBIGUOUS: Mapping[str, List[str]] = {}
 
 
     # triplicates ITEM, KEY, SHOPPING CATEGORY


### PR DESCRIPTION
This PR removes all mypy type-errors from gourmet/defaults. Not everything inside is properly typed, but there are no more errors to throw off the eventual CI check.