### PR TITLE
Update display of Trash window

### DIFF
--- a/gourmet/GourmetRecipeManager.py
+++ b/gourmet/GourmetRecipeManager.py
@@ -1059,7 +1059,7 @@ class RecGui (RecIndex, GourmetApplication, ImporterExporter, StuffThatShouldBeP
 
     def rectree_popup (self, tv, event, *args):
         menu = self.ui_manager.get_widget("/RecipeIndexMenuBar/Actions/").get_submenu()
-        menu.popup(None,None,None,event.button,event.time)
+        menu.popup_at_pointer(None)
         return True
 
     def setup_actions (self):

--- a/gourmet/GourmetRecipeManager.py
+++ b/gourmet/GourmetRecipeManager.py
@@ -545,10 +545,12 @@ class RecTrash (RecIndex):
         top_label.set_markup('<span weight="bold" size="large">'\
                 +_('Trash')+'</span>\n<i>'\
                 +_('Browse, permanently delete or undelete deleted recipes')+'</i>')
-        box.pack_start(top_label,expand=False,fill=False);top_label.show()
+        box.pack_start(top_label, expand=False, fill=False, padding=0)
+        top_label.show()
         self.recipe_index_interface = self.ui.get_object('recipeIndexBox')
         self.recipe_index_interface.unparent()
-        box.pack_start(self.recipe_index_interface,fill=True,expand=True)
+        box.pack_start(self.recipe_index_interface, fill=True,
+                       expand=True, padding=0)
         self.recipe_index_interface.show()
         self.rg.conf.append(WidgetSaver.WindowSaver(self.window,
                                                     self.prefs.get('trash_window',

--- a/gourmet/reccard.py
+++ b/gourmet/reccard.py
@@ -3,7 +3,7 @@ import gc
 import gi
 from gi.repository import GObject
 from gi.repository import Gtk
-from gi.repository import Gdk
+from gi.repository import Gdk, GdkPixbuf
 import os.path
 try:
     from PIL import Image


### PR DESCRIPTION
Recipes can be discarded in a trash, to be deleted for good or restored at a later time.

This PR fixes three things:
- a missing GtkPixbuf import;
- the pop-up that shows up on right-click in the main window;
- updates the costructor calls for the Trash window.

![image](https://user-images.githubusercontent.com/2159577/82552908-56e2e780-9b63-11ea-8cba-8f26860d7ac9.png)
