### PR TITLE
Render reccard content

### DIFF
--- a/gourmet/gtk_extras/TextBufferMarkup.py
+++ b/gourmet/gtk_extras/TextBufferMarkup.py
@@ -15,6 +15,8 @@
 ### along with this library; if not, write to the Free Software
 ### Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
 ### USA
+from typing import Union
+
 import gi
 gi.require_versions({"Gtk": "3.0", "Pango": "1.0"})
 from gi.repository import Pango
@@ -79,11 +81,11 @@ class PangoBuffer (Gtk.TextBuffer):
         #self.set_text(txt)
         Gtk.TextBuffer.__init__(self)
 
-    def set_text (self, txt):
+    def set_text (self, txt: Union[str, bytes]) -> None:
         if isinstance(txt, bytes):
             # data loaded from the database are bytes, not str
             txt = txt.decode()
-        Gtk.TextBuffer.set_text(self,"")
+        Gtk.TextBuffer.set_text(self, txt)   # TODO: should clear the buffer of text
         try:
             self.parsed, attributes, self.txt, self.separator = Pango.parse_markup(txt, -1, '\x00')
         except Exception as e:  # unescaped text (g-markup-error-quark), eg. contains &amp
@@ -110,7 +112,10 @@ class PangoBuffer (Gtk.TextBuffer):
                 tags = self.get_tags_from_attrs(font, lang, attrs)
 
             text = self.txt[start:end]
-            item = self.get_end_attrs_iter()
+            try:
+                item = self.get_end_attrs_iter()
+            except AttributeError:
+                item = self.get_end_iter()
             self.insert_with_tags(item,text,*tags)
 
         #  attrs_iter.destroy()  # TODO: check why calling destroy segfaults.

--- a/gourmet/reccard.py
+++ b/gourmet/reccard.py
@@ -1214,7 +1214,7 @@ class IngredientEditorModule (RecEditorModule):
         add_with_undo(self, lambda *args: self.importIngredients(f))
 
     def paste_ingredients_cb (self, *args):
-        self.cb = Gtk.clipboard_get()
+        self.cb = Gtk.Clipboard()
         def add_ings_from_clippy (cb,txt,data):
             if txt:
                 def do_add ():
@@ -2830,8 +2830,8 @@ class UndoableObjectWithInverseThatHandlesItsOwnUndo (Undo.UndoableObject):
         self.inverse_action()
 
 def add_with_undo (rc,method):
-    idx = rc.recipe_editor.module_tab_by_name["ingredients"]
-    ing_controller = rc.recipe_editor.modules[idx].ingtree_ui.ingController
+    idx = rc.re.module_tab_by_name["ingredients"]
+    ing_controller = rc.re.modules[idx].ingtree_ui.ingController
     uts = UndoableTreeStuff(ing_controller)
 
     def do_it ():

--- a/gourmet/reccard.py
+++ b/gourmet/reccard.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 import gc
+import webbrowser
+
 import gi
 from gi.repository import GObject
 from gi.repository import Gtk
@@ -24,7 +26,7 @@ from .gtk_extras import treeview_extras as te
 from .gtk_extras import cb_extras as cb
 from .exporters.printer import get_print_manager
 from .gdebug import debug
-from .gglobals import FLOAT_REC_ATTRS, INT_REC_ATTRS, REC_ATTR_DIC, REC_ATTRS, doc_base, uibase, imagedir, launch_url
+from .gglobals import FLOAT_REC_ATTRS, INT_REC_ATTRS, REC_ATTR_DIC, REC_ATTRS, doc_base, uibase, imagedir
 from gettext import gettext as _
 from . import ImageExtras as ie
 from .importers.importer import parse_range
@@ -602,7 +604,8 @@ class RecCardDisplay (plugin_loader.Pluggable):
             change_units=self.prefs.get('readableUnits',True)
            )
 
-    def link_cb (self, *args): launch_url(self.link)
+    def link_cb (self, *args):
+        webbrowser.open_new_tab(self.link)
 
     def yields_change_cb (self, widg):
         self.update_yields_multiplier(widg.get_value())
@@ -645,7 +648,7 @@ class RecCardDisplay (plugin_loader.Pluggable):
         # Add new message
         l = Gtk.Label()
         l.set_markup(label)
-        l.connect('activate-link',lambda lbl, uri: launch_url(uri))
+        l.connect('activate-link',lambda lbl, uri: webbrowser.open_new_tab(uri))
         infobar = Gtk.InfoBar()
         infobar.set_message_type(Gtk.MessageType.INFO)
         infobar.get_content_area().add(l)


### PR DESCRIPTION
This aims to fix the rendering of content in the LinkedTextView, but depends on #87 and #88.
Once it's all in, you should be able to create a new recipe using the `New` button, save it to the database, and view it later.

It's still a draft:
- [x] Links are not handled properly;
- [ ] HTML is not handled in the LinkedTextView body content.

There's more stuff, but these are the scope of this PR.

![reccard](https://user-images.githubusercontent.com/2159577/83464164-4c342680-a470-11ea-8f52-a9e8c7061e4c.gif)

