### PR TITLE
Fix the timer

### DIFF
--- a/gourmet/timer.py
+++ b/gourmet/timer.py
@@ -41,7 +41,7 @@ class TimeSpinnerUI:
     def val_changed_cb (self, widg):
         if not widg.val_change_is_changing_entry:
             widg.val_change_is_changing_entry = True
-            widg.set_text(self.pad_n(int(widg.get_value())))
+            widg.set_text(widg.get_text().zfill(2))
             widg.val_change_is_changing_entry = False
 
     def pad_n (self, int):
@@ -87,7 +87,7 @@ class TimeSpinnerUI:
 
     def connect_timer_hook (self, h, prepend=False):
         if prepend:
-            self.timer_hooks = [h] + self.timer_hooks
+            self.timer_hooks.insert(0, h)
         else:
             self.timer_hooks.append(h)
 
@@ -96,7 +96,6 @@ class TimeSpinnerUI:
         for h in self.timer_hooks: h()
 
 
-from .gtk_extras import dialog_extras as de
 
 class TimerDialog:
 

--- a/gourmet/timer.py
+++ b/gourmet/timer.py
@@ -1,12 +1,15 @@
-from gi.repository import Gtk
-from gi.repository import GObject
-import time
-from . import gglobals
 import os
+import time
+
+from gettext import gettext as _
+from gi.repository import Gtk, GObject
 import xml.sax.saxutils
+
+from . import gglobals
 from .sound import Player
 from .gtk_extras import cb_extras as cb
-from gettext import gettext as _
+from .gtk_extras import dialog_extras as de
+
 
 class TimeSpinnerUI:
 

--- a/gourmet/timer.py
+++ b/gourmet/timer.py
@@ -36,14 +36,15 @@ class TimeSpinnerUI:
     def set_time(self, val: float) -> None:
         """Update the spinners on tick.
 
-        Ran on every tick, the value is split into hours, minutes, seconds, and
-        each spinner is set, to show the time going down.
+        Ran on every tick, the value, epoch stamp style, is split into hours,
+        minutes, and seconds, and their respective spinner are set, to show
+        time going down.
         """
-        val = max(0., val)
+        val = max(0, int(val))
         self.hoursSpin.set_value(val // 3600)
         val = val % 3600
         self.minutesSpin.set_value(val // 60)
-        self.secondsSpin.set_value(round(val % 60))
+        self.secondsSpin.set_value(val % 60)
 
     def get_time(self) -> int:
         """Get the time to run the timer for, in seconds"""

--- a/gourmet/timer.py
+++ b/gourmet/timer.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import Callable, Optional
+from typing import Callable, List, Optional, Union
 
 from gettext import gettext as _
 from gi.repository import Gtk, GObject
@@ -18,14 +18,14 @@ class TimeSpinnerUI:
                  hoursSpin: Gtk.SpinButton,
                  minutesSpin: Gtk.SpinButton,
                  secondsSpin: Gtk.SpinButton):
-        self.timer_hooks = []  # Actions to run when timer is over
-        self.is_running = False  # State flag
-        self.elapsed = 0  # The time already spent
-        self.previous_iter_time = None  # epoch stamp, used for loop ticks
-        self.orig_time = 0  # in seconds, the user input time, used for reset
-        self.hoursSpin = hoursSpin
-        self.minutesSpin = minutesSpin
-        self.secondsSpin = secondsSpin
+        self.timer_hooks: List[Callable] = []  # actions rand when timer over
+        self.is_running: bool = False  # State flag
+        self.previous_iter_time: Union[None, int] = None  # time, used for ticks
+        self.orig_time: int = 0  # in seconds, user input time
+
+        self.hoursSpin: Gtk.SpinButton = hoursSpin
+        self.minutesSpin: Gtk.SpinButton = minutesSpin
+        self.secondsSpin: Gtk.SpinButton = secondsSpin
 
         for spinner in (self.hoursSpin, self.minutesSpin, self.secondsSpin):
             # This is set up to assure 2 digit entries... 00:00:00, etc.
@@ -33,13 +33,13 @@ class TimeSpinnerUI:
             spinner.val_change_is_changing_entry = False
             spinner.set_width_chars(2)
 
-    def set_time(self, val: int) -> None:
+    def set_time(self, val: float) -> None:
         """Update the spinners on tick.
 
         Ran on every tick, the value is split into hours, minutes, seconds, and
         each spinner is set, to show the time going down.
         """
-        val = max(0, val)
+        val = max(0., val)
         self.hoursSpin.set_value(val // 3600)
         val = val % 3600
         self.minutesSpin.set_value(val // 60)

--- a/gourmet/timer.py
+++ b/gourmet/timer.py
@@ -27,18 +27,28 @@ class TimeSpinnerUI:
             s.set_value(1)
             s.set_value(0)
 
-    def set_time (self, s):
-        s = int(s)
-        if s < 0: s = 0
-        #self.hoursSpin.set_text(self.pad_n(s / 3600))
-        self.hoursSpin.set_value(s / 3600)
-        s = s % 3600
-        #self.minutesSpin.set_text(self.pad_n(s / 60))
-        self.minutesSpin.set_value(s / 60)
-        #self.secondsSpin.set_text(self.pad_n(s % 60))
-        self.secondsSpin.set_value(s % 60)
+        Ran on every tick, the value is split into hours, minutes, seconds, and
+        each spinner is set, to show the time going down.
+        """
+        if val < 0:
+            val = 0
+        self.hoursSpin.set_value(val // 3600)
+        val = val % 3600
+        self.minutesSpin.set_value(val // 60)
+        self.secondsSpin.set_value(val % 60)
 
-    def val_changed_cb (self, widg):
+    def get_time(self) -> int:
+        """Get the time to run the timer for, in seconds"""
+        hours = self.hoursSpin.get_value()
+        hours *= 3600
+        minutes = self.minutesSpin.get_value()
+        minutes *= 60
+        seconds = self.secondsSpin.get_value()
+
+        return hours + minutes + seconds
+
+    def val_changed_cb(self, widg: Gtk.SpinButton) -> None:
+        """On input callback to set the values to be always two digits"""
         if not widg.val_change_is_changing_entry:
             widg.val_change_is_changing_entry = True
             widg.set_text(widg.get_text().zfill(2))

--- a/gourmet/timer.py
+++ b/gourmet/timer.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional
 
 from gettext import gettext as _
 from gi.repository import Gtk, GObject
@@ -20,7 +20,7 @@ class TimeSpinnerUI:
                  secondsSpin: Gtk.SpinButton):
         self.timer_hooks: List[Callable] = []  # actions rand when timer over
         self.is_running: bool = False  # State flag
-        self.previous_iter_time: Union[None, int] = None  # time, used for ticks
+        self.previous_iter_time: Optional[float] = None  # time, used for ticks
         self.orig_time: int = 0  # in seconds, user input time
 
         self.hoursSpin: Gtk.SpinButton = hoursSpin
@@ -43,7 +43,7 @@ class TimeSpinnerUI:
         self.hoursSpin.set_value(val // 3600)
         val = val % 3600
         self.minutesSpin.set_value(val // 60)
-        self.secondsSpin.set_value(val % 60)
+        self.secondsSpin.set_value(round(val % 60))
 
     def get_time(self) -> int:
         """Get the time to run the timer for, in seconds"""
@@ -109,8 +109,8 @@ class TimeSpinnerUI:
         self.set_time(self.orig_time)
         self.previous_iter_time = 0
 
-    def connect_timer_hook (self, h: Callable,
-                            prepend: Optional[bool] = False) -> None:
+    def connect_timer_hook(self, h: Callable,
+                           prepend: Optional[bool] = False) -> None:
         if prepend:
             self.timer_hooks.insert(0, h)
         else:
@@ -121,7 +121,6 @@ class TimeSpinnerUI:
         self.previous_iter_time = None
         self.set_time(0)
         for h in self.timer_hooks: h()
-
 
 
 class TimerDialog:

--- a/ui/timerDialog.ui
+++ b/ui/timerDialog.ui
@@ -40,7 +40,6 @@
     <property name="gravity">GDK_GRAVITY_NORTH_WEST</property>
     <property name="focus_on_map">True</property>
     <property name="urgency_hint">False</property>
-    <property name="has_separator">True</property>
     <accelerator key="w" modifiers="GDK_CONTROL_MASK" signal="close"/>
     <accelerator key="Escape" modifiers="0" signal="close"/>
     <child internal-child="vbox">


### PR DESCRIPTION
The timer could not be launched, and then was ticking funny due to the change in divisions((counting up sometimes). It also used to skip steps sometimes.

I annotated and commented what I could, and introduced `TimeSpinnerUI.first_iteration` boolean to correctly set the starting time.