### PR TITLE
Fix/web import popup

### DIFF
--- a/gourmet/gtk_extras/dialog_extras.py
+++ b/gourmet/gtk_extras/dialog_extras.py
@@ -262,8 +262,7 @@ class EntryDialog (ModalDialog):
         if default:
             self.entry.set_text(default)
         if entryTip:
-            self.tt = Gtk.Tooltips()
-            self.tt.set_tip(self.entry,entryTip)
+            self.entry.set_tooltip_text(entryTip)
         self.entry.connect("changed",self.update_value)
         # Set the default value after connecting our handler so our
         # value gets updated!

--- a/gourmet/importers/importManager.py
+++ b/gourmet/importers/importManager.py
@@ -216,6 +216,9 @@ class ImportManager (plugin_loader.Pluggable):
         content_type is the mime-type string representation (eg. 'text/html')
 
         The value returned is a string containing the temporary file path.
+
+        TODO: self.tempfiles could store pathlib.Path objects, and this function
+              return these.
         """
         if url in self.tempfiles:
             return self.tempfiles[url]

--- a/gourmet/importers/importManager.py
+++ b/gourmet/importers/importManager.py
@@ -205,7 +205,18 @@ class ImportManager (plugin_loader.Pluggable):
     def get_importer (self, name):
         return self.plugins_by_name[name]
 
-    def get_tempfilename (self, url, data, content_type):
+    def get_tempfilename(self, url: str,
+                         data: bytes,
+                         content_type: str) -> str:
+        """Get a temporary filename for the file to parse.
+
+        The url is a page where a recipe is found, for which Gourmet should have
+        a plugin.
+        data is the retrieved html document.
+        content_type is the mime-type string representation (eg. 'text/html')
+
+        The value returned is a string containing the temporary file path.
+        """
         if url in self.tempfiles:
             return self.tempfiles[url]
         else:
@@ -219,9 +230,8 @@ class ImportManager (plugin_loader.Pluggable):
         else:
             tf = tempfile.mktemp()
         self.tempfiles[url] = tf
-        ofi = open(tf,'w')
-        ofi.write(data)
-        ofi. close()
+        with open(tf, "wb") as fout:
+            fout.write(data)
         return self.tempfiles[url]
 
     def guess_extension (self, content_type):


### PR DESCRIPTION
Here, we update API calls for setting tooltips, which now are not their own objects anymore, but rather belong to the GtkEntry.

This also updates binary access to temporary files in the import manager, as now content retrieved from sockets are bytes, not string.