### PR TITLE
Fix: use the current cursor mark in 'label_selection()'

### DIFF
--- a/gourmet/backends/db.py
+++ b/gourmet/backends/db.py
@@ -2,6 +2,7 @@ from functools import cmp_to_key
 import shutil
 from gourmet.gdebug import debug, TimeAction, debug_decorator
 import re, string, os.path, time
+from typing import Mapping, Optional, List, Any, Tuple
 from gettext import gettext as _
 import gourmet.gglobals as gglobals
 from gourmet import Undo, keymanager, convert
@@ -894,10 +895,10 @@ class RecData (Pluggable, BaseException):
                   ]
         return [x for x in retval if x is not None] # Don't return null values
 
-    def get_ingkeys_with_count (self, search=None):
+    def get_ingkeys_with_count(self, search: Optional[Mapping[str, Any]] = None) -> List[Tuple[int, str]]:
         """Get unique list of ingredient keys and counts for number of times they appear in the database.
         """
-        if search is None:  # replaced mutable default argument: search={}
+        if search is None:
            search = {}
 
         if search:
@@ -911,7 +912,7 @@ class RecData (Pluggable, BaseException):
                 criteria = col.contains(search['search'])
             else:
                 criteria = (col == search['search'])
-            result = sqlalchemy.select(
+            result =  sqlalchemy.select(
                 [sqlalchemy.func.count(self.ingredients_table.c.ingkey).label('count'),
                  self.ingredients_table.c.ingkey],
                 criteria,
@@ -920,7 +921,7 @@ class RecData (Pluggable, BaseException):
                    }
                 ).execute().fetchall()
         else:  # return all ingredient keys with counts
-            result = sqlalchemy.select(
+            result =  sqlalchemy.select(
                 [sqlalchemy.func.count(self.ingredients_table.c.ingkey).label('count'),
                  self.ingredients_table.c.ingkey],
                 **{'group_by':'ingkey',

--- a/gourmet/importers/interactive_importer.py
+++ b/gourmet/importers/interactive_importer.py
@@ -1,4 +1,5 @@
 from gi.repository import Gtk
+from gi.repository import Pango
 from xml.sax.saxutils import escape
 from .generic_recipe_parser import RecipeParser
 import gourmet.gtk_extras.cb_extras as cb
@@ -224,11 +225,10 @@ class InteractiveImporter (ConvenientImporter, NotThreadSafe):
             # Otherwise, there's no clear sane default... we'll just
             # select the current whole line
             cur_mark = self.tb.get_insert()
-            cur_pos=Gtk.TextBuffer.get_iter_at_mark(cur_pos)
+            cur_pos=Gtk.TextBuffer.get_iter_at_mark(cur_mark)
             cur_pos.backward_chars(
                 cur_pos.get_line_offset())
             st = cur_pos
-            end = cur_pos.copy()
             end = cur_pos.forward_line()
         self.label_range(st,end,label)
 


### PR DESCRIPTION
This change provide 3 fixes:
1. The current TextBuffer position 'cur_mark' is set in method 'label_selection()' but not used. 'cur_pos' is incorrectly passed as the argument in 'get_iter_at_mark()'. 
2. Local var 'end' is defined twice before it is used in method 'label_selection()'
3. Added an import statement for Pango