### PR TITLE
Reverse time units iteration

### DIFF
--- a/gourmet/convert.py
+++ b/gourmet/convert.py
@@ -602,9 +602,9 @@ def seconds_to_timestring (time, round_at=None, fractions=FRACTIONS_NORMAL):
     time = int(time)
     time_strings = []
     units = list(Converter.unit_to_seconds.items())
-    units.sort(key=lambda x: x[1]) #old cmp-func: lambda a,b: a[1]<b[1] and 1 or a[1]>b[1] and -1 or 0
+    units.sort(key=lambda x: x[1], reverse=True)
     for unit,divisor in units:
-        time_covered = time / int(divisor)
+        time_covered = time // int(divisor)
         # special case hours, which we English speakers anyway are
         # used to hearing in 1/2s -- i.e. 1/2 hour is better than 30
         # minutes.

--- a/gourmet/convert.py
+++ b/gourmet/convert.py
@@ -1,10 +1,12 @@
 import re, locale, math
 import collections.abc
+from typing import Optional
 from .defaults.defaults import lang as defaults
 from gettext import gettext as _
 from gettext import ngettext
 from .gdebug import debug
 
+# TODO: these should be turned into Enums
 FRACTIONS_ALL = 1
 FRACTIONS_NORMAL = 0
 FRACTIONS_ASCII = -1
@@ -598,8 +600,9 @@ time_formatters = {
     'seconds':lambda seconds: ngettext("second","seconds",seconds),
     }
 
-def seconds_to_timestring (time, round_at=None, fractions=FRACTIONS_NORMAL):
-    time = int(time)
+def seconds_to_timestring(time: int,
+                          round_at: Optional[int] = None,
+                          fractions: int = FRACTIONS_NORMAL):
     time_strings = []
     units = list(Converter.unit_to_seconds.items())
     units.sort(key=lambda x: x[1], reverse=True)


### PR DESCRIPTION
@maweki , this closes #117 

The units were being iterated from seconds up, whereas it must be from years down.
Thanks for the pointers.

I think the enums should be done in another PR