### PR TITLE
Turn ValueError loading Gst into ImportError, allowing fallback

### DIFF
--- a/gourmet/sound_gst.py
+++ b/gourmet/sound_gst.py
@@ -1,5 +1,9 @@
 from gi import require_version
-require_version('Gst', '1.0')
+try:
+    require_version('Gst', '1.0')
+except ValueError as e:
+    # gourmet.sound catches ImportError
+    raise ImportError("Gst not available") from e
 from gi.repository import Gst
 
 class Player:


### PR DESCRIPTION
This is causing a couple of test failures on master at the moment.

cc @saxon-s