### PR TITLE
Fix test_importers.py

### DIFF
--- a/gourmet/check_encodings.py
+++ b/gourmet/check_encodings.py
@@ -51,14 +51,15 @@ class CheckEncoding:
 
     def test_all_encodings (self,encodings=None):
         """Test all encodings and return a dictionary of possible encodings."""
-        if not encodings: encodings=self.all_encodings
+        if not encodings:
+            encodings=self.all_encodings
         self.possible_encodings = {}
         for e in encodings:
             try:
                 d=self.txt.decode(e)
-                if d and (not d in list(self.possible_encodings.values())):
+                if d and (d not in self.possible_encodings.values()):
                     # if we don't already have this possibility, add
-                    self.possible_encodings[e]=d.encode('utf8')
+                    self.possible_encodings[e] = d
             except UnicodeDecodeError:
                 pass
         return self.possible_encodings
@@ -76,7 +77,6 @@ class GetFile (CheckEncoding):
             self.enc = encoding
             self.lines = encs[self.enc].splitlines()
             debug('reading file %s as encoding %s'%(file, self.enc))
-            self.lines = [l.encode() for l in self.lines]
         else:
             raise Exception("Cannot decode file %s" % file)
 

--- a/gourmet/check_encodings.py
+++ b/gourmet/check_encodings.py
@@ -106,7 +106,7 @@ class EncodingDialog (de.OptionDialog):
         de.OptionDialog.__init__(self, default=default,label=label, sublabel=sublabel,
                                  options=self.options, expander=expander)
         self.set_default_size(700,500)
-        self.optionMenu.connect('activate',self.change_encoding)
+        self.combobox.connect('changed',self.change_encoding)
         self.change_encoding()
         self.created = False
         self.expander.set_expanded(True)
@@ -154,7 +154,7 @@ class EncodingDialog (de.OptionDialog):
             self.line_highlight_tags = [self.encoding_buffers[k].create_tag(background='green')]
             self.set_buffer_text(self.encoding_buffers[k],t)
 
-    def change_encoding (self):
+    def change_encoding (self, _widget=None):
         if self.cursor_already_set:
             im=self.buffer.get_insert()
             ti=self.buffer.get_iter_at_mark(im)

--- a/gourmet/gtk_extras/dialog_extras.py
+++ b/gourmet/gtk_extras/dialog_extras.py
@@ -323,35 +323,27 @@ class OptionDialog (ModalDialog):
         """Options can be a simple option or can be a tuple or a list
         where the first item is the label and the second the value"""
         ModalDialog.__init__(self, okay=True, label=label, sublabel=sublabel, parent=parent, expander=expander, cancel=cancel)
-        self.menucb = self.get_option
-        self.optdic={}
-        self.menu = Gtk.Menu()
-        # set the default value to the first item
-        first = options[0]
-        if isinstance(first, str):
-            self.ret = first
-        else:
-            self.ret = first[1]
+
+        self.combobox = Gtk.ComboBoxText()
+        self.vbox.pack_start(
+            self.combobox, expand=False, fill=False, padding=0
+        )
+        self.option_values = []
         for o in options:
             if isinstance(o, str):
-                l=o
-                v=o
+                label = value = o
             else:
-                l=o[0]
-                v=o[1]
-            i = Gtk.MenuItem(l)
-            i.connect('activate',self.menucb)
-            i.show()
-            self.optdic[i]=v
-            self.menu.append(i)
-        self.optionMenu=Gtk.OptionMenu()
-        self.vbox.pack_start(self.optionMenu, expand=False, fill=False, padding=0)
-        self.optionMenu.set_menu(self.menu)
-        self.optionMenu.show()
-        self.menu.show()
+                label, value = o
+            self.combobox.append_text(label)
+            self.option_values.append(value)
+
+        # set the default value to the first item
+        self.ret = self.option_values[0]
+        self.combobox.connect('changed', self.get_option)
+        self.combobox.show()
 
     def get_option (self, widget):
-        self.ret=self.optdic[widget]
+        self.ret = self.option_values[self.combobox.get_active()]
         #return self.ret
 
     def set_value (self, value):

--- a/gourmet/importers/importer.py
+++ b/gourmet/importers/importer.py
@@ -455,19 +455,23 @@ class Tester:
             self.matcher = re.compile(self.regexp)
         CLOSE=False
         if isinstance(filename, str):
-            self.ofi = open(filename,'r')
+            # Latin-1 can decode any bytes, letting us open ASCII-compatible
+            # text files and sniff their contents - e.g. for XML tags -
+            # without worrying too much about their real text encoding.
+            ofi = open(filename, 'r', encoding='latin1')
             CLOSE=True
-        else: self.ofi=filename
-        l = self.ofi.readline()
-        while l:
-            if self.matcher.match(l):
-                self.ofi.close()
-                return True
-            l = self.ofi.readline()
-        if CLOSE:
-            self.ofi.close()
         else:
-            self.ofi.seek(0)
+            ofi = filename
+
+        try:
+            for l in ofi:
+                if self.matcher.match(l):
+                    return True
+        finally:
+            if CLOSE:
+                ofi.close()
+            else:
+                ofi.seek(0)
 
 class RatingConverter:
 

--- a/gourmet/importers/plaintext_importer.py
+++ b/gourmet/importers/plaintext_importer.py
@@ -41,7 +41,7 @@ class TextImporter (importer.Importer):
             self.commit_rec()
         importer.Importer.do_run(self)
 
-    def handle_line (self):
+    def handle_line (self, l):
         raise NotImplementedError
 
     def compile_regexps (self):

--- a/gourmet/importers/xml_importer.py
+++ b/gourmet/importers/xml_importer.py
@@ -57,7 +57,10 @@ class Converter (importer.Importer):
         # count the recipes in the file
         t = TimeAction("rxml_to_metakit.run counting lines",0)
         if isinstance(self.fn, str):
-            f = open(self.fn, 'rb')
+            # Latin-1 can decode any bytes, letting us open ASCII-compatible
+            # text files and sniff their contents - e.g. for XML tags -
+            # without worrying about their real text encoding.
+            f = open(self.fn, 'r', encoding='latin1')
         else:
             f=self.fn
         recs = 0

--- a/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py
+++ b/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_importer.py
@@ -18,12 +18,12 @@ class Mx2Cleaner:
         self.encodings = ['cp1252','iso8859','ascii','latin_1','cp850','utf-8']
 
     def cleanup (self, infile, outfile):
-        infile = open(infile,'r')
-        outfile = open(outfile,'w')
+        infile = open(infile, 'rb')
+        outfile = open(outfile,'w', encoding='utf-8')
         for l in infile.readlines():
+            l = self.decode(l)
             l = self.toss_regs(l)
             l = self.fix_attrs(l)
-            l = self.encode(l)
             outfile.write(l)
         infile.close()
         outfile.close()
@@ -51,14 +51,15 @@ class Mx2Cleaner:
         outstr = outstr + instr
         return outstr
 
-    def encode (self, l):
+    def decode (self, l: bytes) -> str:
+        """Try several encodings, return the line once it's succesfully decoded
+        """
         for e in self.encodings:
             try:
                 return l.decode(e)
-            except:
+            except UnicodeDecodeError:
                 debug('Could not decode as %s'%e,2)
                 pass
-        raise Exception("Could not encode %s" % l)
 
 class MastercookXMLHandler (xml_importer.RecHandler):
     """We handle MasterCook XML Files"""
@@ -123,7 +124,8 @@ class MastercookXMLHandler (xml_importer.RecHandler):
             pass
 
     def characters (self, ch):
-        debug('adding to %s bufs: %s'%(len(self.bufs),ch),0)
+        if self.bufs:
+            debug('adding to %s bufs: %s'%(len(self.bufs),ch),0)
         for buf in self.bufs:
             setattr(self,buf,getattr(self,buf)+ch)
 

--- a/gourmet/tests/test_importers.py
+++ b/gourmet/tests/test_importers.py
@@ -110,7 +110,7 @@ class ImportTest:
         for blobby_attribute in ['instructions','modifications']:
             if test.get(blobby_attribute,False):
                 match_text = test[blobby_attribute]
-                match_text = re.sub('\s+','\s+',match_text)
+                match_text = re.sub(r'\s+', r'\\s+', match_text)
                 try:
                     assert(re.match(match_text,getattr(rec,blobby_attribute)))
                 except:


### PR DESCRIPTION
See #28

This is separated out from #116. It doesn't actually fix the importer tests in CI (trying to solve that revealed much bigger issues, which led to separating this out), but running just those tests in isolation succeeds:

```
nosetests gourmet/tests/test_importers.py
```

I think these changes are an improvement by themselves, even if they don't fix the tests in CI.