### PR TITLE
Prepare plugins in CI before running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,8 @@ jobs:
         sudo pip3 install flake8 nose mypy
         sudo pip3 install --upgrade keyrings.alt
         if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
+    - name: Prepare plugins
+      run: python3 setup.py build
     - name: Test with nose
       run: |
         xvfb-run -a nosetests -v gourmet/tests/test_*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         sudo apt-get update -q && sudo apt-get install
         --no-install-recommends -y xvfb python3-dev python3-gi
         python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev
-        libcairo2-dev enchant
+        libcairo2-dev enchant intltool
     - name: Install dependencies
       run: |
         sudo python3 -m pip install --upgrade pip
@@ -33,7 +33,7 @@ jobs:
         sudo pip3 install --upgrade keyrings.alt
         if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
     - name: Prepare plugins
-      run: python3 setup.py build
+      run: python3 setup.py build_i18n
     - name: Test with nose
       run: |
         xvfb-run -a nosetests -v gourmet/tests/test_*


### PR DESCRIPTION
Running `setup.py build_i18n` is necessary for gourmet to find the plugins it comes with - it converts the `.gourmet-plugins.in` files to `.gourmet-plugin` files in the build folder, found because of this line:

https://github.com/kirienko/gourmet/blob/1e46480501cfddd592a68fa6526e5290556f5707/gourmet/settings.py#L13

This is fairly slow (it runs a new process to convert each `.in` file), and causes more test failures by exposing more functionality to test, and more room for interactions between different tests. But at some point it's going to be necessary to include those plugins in tests.