### PR TITLE
Fix testAvailablePlugins

### DIFF
--- a/gourmet/plugin_loader.py
+++ b/gourmet/plugin_loader.py
@@ -150,7 +150,7 @@ class MasterLoader:
                         raise
         return depending_on_me
 
-    def activate_plugin_set (self, plugin_set):
+    def activate_plugin_set (self, plugin_set: 'PluginSet'):
         """Activate a set of plugins.
         """
         if plugin_set in self.active_plugin_sets:
@@ -159,8 +159,9 @@ class MasterLoader:
         # plugin_set.get_module() returns None if there's been a
         # problem -- we want to raise that problem now.
         if plugin_set.get_module() is None:
-            self.errors[plugin_set]=plugin_set.error.__class__.__name__+': '+plugin_set.error.message
-            raise plugin_set.error
+            e = plugin_set.error
+            self.errors[plugin_set] = f"{type(e).__name__}: {e}"
+            raise e
         self.active_plugin_sets.append(plugin_set.module)
         self.active_plugins.extend(plugin_set.plugins)
         for plugin in plugin_set.plugins:
@@ -169,7 +170,7 @@ class MasterLoader:
                     for pluggable in self.pluggables_by_class[klass]:
                         pluggable.plugin_plugin(self.get_instantiated_plugin(plugin))
 
-    def deactivate_plugin_set (self, plugin_set):
+    def deactivate_plugin_set (self, plugin_set: 'PluginSet'):
         # Deactivate any plugin sets that depend upon us...
         for ps in self.check_if_depended_upon(plugin_set):
             self.deactivate_plugin_set(ps)

--- a/gourmet/tests/test_plugin_loader.py
+++ b/gourmet/tests/test_plugin_loader.py
@@ -29,9 +29,9 @@ class Test (unittest.TestCase):
 
     def testAvailablePlugins (self):
         ml = get_master_loader()
-        for st in ml.available_plugin_sets:
-            if st not in ml.active_plugins:
-                ml.activate_plugin_set(st)
+        for module_name, plugin_set in ml.available_plugin_sets.items():
+            if module_name not in ml.active_plugin_sets:
+                ml.activate_plugin_set(plugin_set)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
To get rid of this failure:

```
======================================================================
ERROR: testAvailablePlugins (gourmet.tests.test_plugin_loader.Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/gourmet/gourmet/gourmet/tests/test_plugin_loader.py", line 34, in testAvailablePlugins
    ml.activate_plugin_set(st)
  File "/home/runner/work/gourmet/gourmet/gourmet/plugin_loader.py", line 158, in activate_plugin_set
    self.check_dependencies(plugin_set)
  File "/home/runner/work/gourmet/gourmet/gourmet/plugin_loader.py", line 127, in check_dependencies
    if plugin_set.dependencies:
AttributeError: 'str' object has no attribute 'dependencies'
```

This probably won't result in fewer failures, because clearing the relatively simple error out of the way means more room for complicated things to go wrong.