### PR TITLE
Fix time link hover

### DIFF
--- a/gourmet/gtk_extras/LinkedTextView.py
+++ b/gourmet/gtk_extras/LinkedTextView.py
@@ -140,18 +140,16 @@ class LinkedTextView(Gtk.TextView):
         """Set the mouse cursor to be a hand when hovering over a time link.
 
         Check each tag covering the position (x, y) within the text view.
-        If the text happens to be blue, which only time links are allowed to be
-        in this application, then set the cursor to a hand.
-        If leaving the area of a time link, set the cursor back to the system's
-        default.
+        If the text happens to be coloured, which only time links are allowed
+        to be in this application, then set the cursor to a hand.
+        If leaving the area of a time link, set the cursor to an I-beam.
         """
         _, itr = text_view.get_iter_at_location(x, y)
         tags = itr.get_tags()
-        blue = Gdk.Color(red=0, green=0, blue=65535)
 
         hovering_over_link = False
         for tag in tags:
-            if tag.get_property('foreground-gdk') == blue:
+            if isinstance(tag.get_property('foreground-gdk'), Gtk.Color):
                 hovering_over_link = True
                 break
 

--- a/gourmet/gtk_extras/LinkedTextView.py
+++ b/gourmet/gtk_extras/LinkedTextView.py
@@ -19,12 +19,12 @@
 # Largely based on hypertext.py example in pygtk docs by
 # Maik Hertha <maik.hertha@berlin.de>
 
+import re
 from gi.repository import Gdk, GObject, Gtk, Pango
-import re, xml.sax.saxutils
-from .TextBufferMarkup import PangoBuffer
-from gourmet.gdebug import debug
+from gourmet.gtk_extras.TextBufferMarkup import PangoBuffer
 
-class LinkedPangoBuffer (PangoBuffer):
+
+class LinkedPangoBuffer(PangoBuffer):
 
     href_regexp = re.compile(r"<a href=['\"]([^'\"]+)['\"][^>]*>(.*?)</a>")
 
@@ -73,12 +73,13 @@ class LinkedPangoBuffer (PangoBuffer):
             print('Funny',text,'looks like a link, but is not in markup_dict',self.markup_dict)
         PangoBuffer.insert_with_tags(self,itr,text,*tags)
 
-class LinkedTextView (Gtk.TextView):
+
+class LinkedTextView(Gtk.TextView):
     __gtype_name__ = 'LinkedTextView'
 
     hovering_over_link = False
     hand_cursor = Gdk.Cursor.new(Gdk.CursorType.HAND2)
-    regular_cursor = Gdk.Cursor.new(Gdk.CursorType.XTERM)
+    text_cursor = Gdk.Cursor.new(Gdk.CursorType.XTERM)  # I-beam shaped
 
     __gsignals__ = {
         'link-activated':(GObject.SignalFlags.RUN_LAST,
@@ -132,26 +133,32 @@ class LinkedTextView (Gtk.TextView):
         self.follow_if_link(text_view, iter)
         return False
 
-    # Looks at all tags covering the position (x, y) in the text view,
-    # and if one of them is a link, change the cursor to the "hands" cursor
-    # typically used by web browsers.
-    def set_cursor_if_appropriate(self, text_view, x, y):
-        hovering = False
-        _, iter_ = text_view.get_iter_at_location(x, y)
-        tags = iter_.get_tags()
+    def set_cursor_if_appropriate(self,
+                                  text_view: 'LinkedTextView',
+                                  x: int,
+                                  y: int) -> None:
+        """Set the mouse cursor to be a hand when hovering over a time link.
 
+        Check each tag covering the position (x, y) within the text view.
+        If the text happens to be blue, which only time links are allowed to be
+        in this application, then set the cursor to a hand.
+        If leaving the area of a time link, set the cursor back to the system's
+        default.
+        """
+        _, itr = text_view.get_iter_at_location(x, y)
+        tags = itr.get_tags()
+        blue = Gdk.Color(red=0, green=0, blue=65535)
+
+        hovering_over_link = False
         for tag in tags:
-            href = tag.get_data("href")
-            if href:
-                hovering = True
+            if tag.get_property('foreground-gdk') == blue:
+                hovering_over_link = True
                 break
-        if hovering != self.hovering_over_link:
-            self.hovering_over_link = hovering
 
-        if self.hovering_over_link:
-            text_view.get_window(Gtk.TextWindowType.TEXT).set_cursor(self.hand_cursor)
-        else:
-            text_view.get_window(Gtk.TextWindowType.TEXT).set_cursor(self.regular_cursor)
+        cursor = self.text_cursor
+        if hovering_over_link:
+            cursor = self.hand_cursor
+        text_view.get_window(Gtk.TextWindowType.TEXT).set_cursor(cursor)
 
     # Update the cursor image if the pointer moved.
     def motion_notify_event(self, text_view, event):


### PR DESCRIPTION
Gourmet, in its rich text widgets such as displaying the recipe, supports time links.
These time links are created by parsing the recipe and finding strings related to time, and create a link using Pango for rendering.
When clicked, these are meant to show a timer.

For a more intuitive usage, time links have the same behaviour as links in a browser: they are blue and underscored, and the cursor changes from an I-beam to a hande, as one would intuitively expect.

This fixes that, as shown below:
![time_link](https://user-images.githubusercontent.com/2159577/86444757-916aa300-bd11-11ea-8253-307292a664bb.gif)

(When entering the TextView, the cursor becomes an I-beam, for text selection, and a hand when hovering a link).

Historically, one could set and check custom properties in a `Gtk.TextTag`. This is no longer allowed.
A workaround is to use `setattr` and `getattr` to set a flag:
```python
setattr(tag, 'is_a_link', True)
```

However, since tags will now be created automatically, setting custom attributes to a tag is difficult.

As Gourmet has a rather simple markup grammar, with only italic, bold, underlined, and blue text allowed, we can rely on the text color being blue to indicate a link.