### PR TITLE
Fixed Star Widget

### DIFF
--- a/gourmet/gtk_extras/ratingWidget.py
+++ b/gourmet/gtk_extras/ratingWidget.py
@@ -273,14 +273,10 @@ class StarButton (Gtk.Button):
         x,y = event.get_coords() # coordinates relative to widget
         wx,wy = self.translate_coordinates(self.image,int(x),int(y)) # coordinates relative to star images
         wx = min(self.image.get_pixbuf().get_width(), max(0, wx)) # clamp x values to star range
+        # clamping of pixel values is fine as the user can click outside the stars of the widget to get to 0 or 10
         self.star_width =  self.image.get_pixbuf().get_width() / self.image.upper
         star = x // self.star_width
-        if self.image.value >= star:
-            # if we're clicking on a set icon, we want it to go away
-            self.set_value(star-1)
-        else:
-            # otherwise we want it to be filled
-            self.set_value(star)
+        self.set_value(star)
         return True
 
     def keypress_cb (self, widget, event):
@@ -398,14 +394,9 @@ class TreeWithStarMaker:
                 itr=mod.get_iter(path)
                 curval=mod.get_value(itr,0)
                 self.star_width = self.cellrenderer.get_property('pixbuf').get_width()/self.upper
-                starval = cellx / self.star_width + 1
+                starval = (cellx + 0.5 * self.star_width) // self.star_width # we translate this half a half-star since you can't click before 0, other than in the widget
                 curval = mod.get_value(itr,self.data_col)
-                if starval > curval:
-                    self.call_handlers(starval, mod, itr, self.data_col)
-                    #mod.set_value(itr,self.col_position,starval)
-                else:
-                    self.call_handlers(starval-1, mod, itr, self.data_col)
-                    #mod.set_value(itr,self.col_position,starval-1)
+                self.call_handlers(starval, mod, itr, self.data_col)
             self.curpath = path
 
     def tree_keypress_callback (self, tv, event):

--- a/gourmet/gtk_extras/ratingWidget.py
+++ b/gourmet/gtk_extras/ratingWidget.py
@@ -270,9 +270,9 @@ class StarButton (Gtk.Button):
         return True
 
     def buttonpress_cb (self, widget, event):
-        x,y = event.get_coords() # coordinates relative to widget
-        wx,wy = self.translate_coordinates(self.image,int(x),int(y)) # coordinates relative to star images
-        wx = min(self.image.get_pixbuf().get_width(), max(0, wx)) # clamp x values to star range
+        x, y = event.get_coords()  # coordinates relative to widget
+        wx, wy = self.translate_coordinates(self.image, int(x), int(y))  # coordinates relative to star images
+        wx = min(self.image.get_pixbuf().get_width(), max(0, wx))  # clamp x values to star range
         # clamping of pixel values is fine as the user can click outside the stars of the widget to get to 0 or 10
         self.star_width =  self.image.get_pixbuf().get_width() / self.image.upper
         star = x // self.star_width
@@ -394,7 +394,7 @@ class TreeWithStarMaker:
                 itr=mod.get_iter(path)
                 curval=mod.get_value(itr,0)
                 self.star_width = self.cellrenderer.get_property('pixbuf').get_width()/self.upper
-                starval = (cellx + 0.5 * self.star_width) // self.star_width # we translate this half a half-star since you can't click before 0, other than in the widget
+                starval = (cellx + 0.5 * self.star_width) // self.star_width  # we translate this half a half-star since you can't click before 0, as opposed to the method in the widget
                 curval = mod.get_value(itr,self.data_col)
                 self.call_handlers(starval, mod, itr, self.data_col)
             self.curpath = path

--- a/gourmet/gtk_extras/ratingWidget.py
+++ b/gourmet/gtk_extras/ratingWidget.py
@@ -463,7 +463,7 @@ if __name__ == '__main__':
     s = StarGenerator()
     for i in range(10):
         hb = Gtk.HBox()
-        hb.pack_start(StarButton(s,start_value=i),fill=False,expand=False)
+        hb.pack_start(StarButton(s,start_value=i),False,False,0)
         vb.add(hb)
     w=Gtk.Window()
     w.add(vb)

--- a/gourmet/gtk_extras/ratingWidget.py
+++ b/gourmet/gtk_extras/ratingWidget.py
@@ -270,11 +270,11 @@ class StarButton (Gtk.Button):
         return True
 
     def buttonpress_cb (self, widget, event):
-        x,y = event.get_coords()
-        wx,wy = self.image.translate_coordinates(self.image,int(x),int(y))
+        x,y = event.get_coords() # coordinates relative to widget
+        wx,wy = self.translate_coordinates(self.image,int(x),int(y)) # coordinates relative to star images
+        wx = min(self.image.get_pixbuf().get_width(), max(0, wx)) # clamp x values to star range
         self.star_width =  self.image.get_pixbuf().get_width() / self.image.upper
-        star = x / self.star_width + 1
-        star = int(star)
+        star = x // self.star_width
         if self.image.value >= star:
             # if we're clicking on a set icon, we want it to go away
             self.set_value(star-1)

--- a/gourmet/recindex.py
+++ b/gourmet/recindex.py
@@ -576,6 +576,8 @@ class RecIndex:
                 )
             # self.rmodel.row_changed(self.rmodel.get_path(treeiter),treeiter)
             self.rmodel.update_iter(treeiter)
+            model.set_value(treeiter, column_number, value)
+
 
     def update_modified_recipe(self,rec,attribute,text):
         """Update a modified recipe.

--- a/gourmet/recindex.py
+++ b/gourmet/recindex.py
@@ -568,8 +568,6 @@ class RecIndex:
                         model: 'RecipeModel',
                         treeiter: Gtk.TreeIter,
                         column_number: int) -> None:
-        # itr = model.convert_iter_to_child_iter(None,treeiter)
-        # self.rmodel.set_value(treeiter,column_number,value)
         rec = self.get_rec_from_iter(treeiter)
         if getattr(rec,'rating')!=value:
             self.rd.undoable_modify_rec(
@@ -578,7 +576,6 @@ class RecIndex:
                 self.history,
                 get_current_rec_method = lambda *args: self.get_selected_recs_from_rec_tree()[0],
                 )
-            # self.rmodel.row_changed(self.rmodel.get_path(treeiter),treeiter)
             self.rmodel.update_iter(treeiter)
             model.set_value(treeiter, column_number, value)
 

--- a/gourmet/recindex.py
+++ b/gourmet/recindex.py
@@ -563,7 +563,11 @@ class RecIndex:
             sb.set_value(sb.get_adjustment().get_upper())
             return True
 
-    def star_change_cb (self, value, model, treeiter, column_number):
+    def star_change_cb (self,
+                        value: float,
+                        model: 'RecipeModel',
+                        treeiter: Gtk.TreeIter,
+                        column_number: int) -> None:
         # itr = model.convert_iter_to_child_iter(None,treeiter)
         # self.rmodel.set_value(treeiter,column_number,value)
         rec = self.get_rec_from_iter(treeiter)


### PR DESCRIPTION
So I took a pass at the rating widget. I simplified the method to select the rating. Formerly it was, if you click on a value that is already selected, you remove that one. Also the relative positions were wrong. All quite confusing and I simplified it in a concise manner.

There was also an update missing in the main recipe view when the rating value was changed and I added that.