### PR TITLE
flatpak manifest (org.flatpak.Gourmet.yml) and build instructions (flatpak.yaml)--also updated INSTALL.md

### DIFF
--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -1,0 +1,23 @@
+on: tag
+
+jobs: 
+  build: flatpack
+  - uses: actions/checkout@v2   # automatically clone the repository
+    runs-on: ubuntu-20.04  # verified on ubuntu-20.04 and should run on any debian distro
+    
+    - name: install Flatpak
+      run: >
+        sudo apt install flatpak gnome-software-plugin-flatpak && flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && flatpak install flathub org.gnome.Platform//3.36 org.gnome.Sdk//3.36 org.flatpak.Builder
+      
+    - name: build Flatpak  # run command in an empty directory with org.flatpak.Gourmet.yml placed in it
+      run: >
+        flatpak-builder build-dir org.flatpak.Gourmet.yml 
+        
+    - name: run Flatpak  # run in same directory as buildFlatpak
+      run: >
+        flatpak-builder --run --socket=fallback-x11 build-dir org.flatpak.Gourmet.yml gourmet
+     
+# Until issue # 107 is fixed, in the directory Gourmet was built in, open the settings.py in the following path
+# .../build-dir/files/lib/python3.8/site-packages/gourmet/settings.py
+# and change line 7 to:
+# base_dir = '/app/share/gourmet'

--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -1,19 +1,25 @@
-on: tag
+on: 
+  push:
+    tags:
+      - '*'
 
 jobs: 
-  build: flatpack
-  - uses: actions/checkout@v2   # automatically clone the repository
+  flatpak:
+     
     runs-on: ubuntu-20.04  # verified on ubuntu-20.04 and should run on any debian distro
     
-    - name: install Flatpak
+    steps:
+    - uses: actions/checkout@v2 
+    - name: Install Flatpak
       run: >
-        sudo apt install flatpak gnome-software-plugin-flatpak && flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && flatpak install flathub org.gnome.Platform//3.36 org.gnome.Sdk//3.36 org.flatpak.Builder
+        sudo apt install flatpak gnome-software-plugin-flatpak && flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        flatpak install flathub org.gnome.Platform//3.36 org.gnome.Sdk//3.36 org.flatpak.Builder
       
-    - name: build Flatpak  # run command in an empty directory with org.flatpak.Gourmet.yml placed in it
+    - name: Build Flatpak  # run command in an empty directory with org.flatpak.Gourmet.yml placed in it
       run: |
         flatpak-builder build-dir org.flatpak.Gourmet.yml 
         
-    - name: run Flatpak  # run in same directory as buildFlatpak
+    - name: Run Flatpak  # run in same directory as buildFlatpak
       run: |
         flatpak-builder --run --socket=fallback-x11 build-dir org.flatpak.Gourmet.yml gourmet
      

--- a/.github/workflows/flatpak.yaml
+++ b/.github/workflows/flatpak.yaml
@@ -10,11 +10,11 @@ jobs:
         sudo apt install flatpak gnome-software-plugin-flatpak && flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && flatpak install flathub org.gnome.Platform//3.36 org.gnome.Sdk//3.36 org.flatpak.Builder
       
     - name: build Flatpak  # run command in an empty directory with org.flatpak.Gourmet.yml placed in it
-      run: >
+      run: |
         flatpak-builder build-dir org.flatpak.Gourmet.yml 
         
     - name: run Flatpak  # run in same directory as buildFlatpak
-      run: >
+      run: |
         flatpak-builder --run --socket=fallback-x11 build-dir org.flatpak.Gourmet.yml gourmet
      
 # Until issue # 107 is fixed, in the directory Gourmet was built in, open the settings.py in the following path

--- a/org.flatpak.Gourmet.yml
+++ b/org.flatpak.Gourmet.yml
@@ -1,0 +1,54 @@
+app-id: org.flatpak.Gourmet
+runtime: org.gnome.Platform
+runtime-version: '3.36'
+sdk: org.gnome.Sdk
+command: gourmet
+finish-args:
+  - --share=network
+modules:
+  - name: cpython
+    sources: 
+      - type: archive
+        url:  https://www.python.org/ftp/python/3.8.4/Python-3.8.4.tar.xz
+        sha256:  5f41968a95afe9bc12192d7e6861aab31e80a46c46fa59d3d837def6a4cd4d37
+        
+  - name: intltool
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url:  https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        sha256:  67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+
+  - name: dbus-python
+    buildsystem: simple
+    build-commands:
+      - python3 setup.py install --prefix=/app
+    sources:
+      - type: git
+        url:  https://gitlab.freedesktop.org/dbus/dbus-python
+               
+  - name: PrePipDependencies
+    buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
+    build-commands:
+      - pip3 install pyenchant sphinx pgi PyGObject gobject
+               
+  - name: PipDependencies
+    buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
+    build-commands:
+      - pip3 install pygtkspellcheck reportlab lxml keyring dogtail scrape-schema-recipe ebooklib sqlalchemy Pillow gobject beautifulsoup4 pycairo selenium pyglet giofile
+
+  - name: gourmet
+    ensure-writable:
+      - /lib/python2.7/site-packages/easy-install.pth
+    buildsystem: simple
+    build-commands:
+      - python3 setup.py install --prefix=/app
+    sources: 
+      - type: git
+        url:  https://github.com/kirienko/gourmet


### PR DESCRIPTION
This flatpak manifest (org.flatpak.Gourmet.yml) works for me in Ubuntu 20.04, but the manifest should work in any distro.  The build instructions (flatpak.yaml) will vary by distro, but it works in Ubuntu 20.04.