### PR TITLE
Use RecGui instance instead of new object in file imports

### DIFF
--- a/gourmet/GourmetRecipeManager.py
+++ b/gourmet/GourmetRecipeManager.py
@@ -21,7 +21,7 @@ from gourmet.exporters.printer import get_print_manager
 from gourmet.gdebug import debug
 from gourmet.gglobals import (DEFAULT_HIDDEN_COLUMNS, REC_ATTRS, doc_base,
                               icondir, uibase)
-from gourmet.importers.importManager import get_import_manager
+from gourmet.importers.importManager import ImportManager
 
 
 from gourmet.gtk_extras import (
@@ -647,7 +647,7 @@ def launch_webbrowser(dialog, link, user_data):
 
 
 def launch_app():
-    RecGui()
+    RecGui.instance()
     Gtk.main()
 
 
@@ -676,14 +676,14 @@ class ImporterExporter:
     @property
     def importManager(self):
         if self.__import_manager is None:
-            self.__import_manager = get_import_manager()
+            self.__import_manager = ImportManager.instance()
         return self.__import_manager
 
-    def import_webpageg (self, *args):
+    def import_webpageg(self, action: Gtk.Action):
         self.importManager.offer_web_import(parent=self.app.get_toplevel())
 
-    def do_import (self, *args):
-        self.importManager.offer_import(self.window)
+    def do_import(self, action: Gtk.Action):
+        self.importManager.offer_import(parent=self.app.get_toplevel())
 
     __export_manager = None
 
@@ -860,7 +860,7 @@ class RecGui (RecIndex, GourmetApplication, ImporterExporter, StuffThatShouldBeP
 
         return RecGui.__single
 
-    def __init__ (self):
+    def __init__(self):
         self.ui_manager = Gtk.UIManager()
         self.ui_manager.add_ui_from_string(ui_string)
 

--- a/gourmet/batchEditor.py
+++ b/gourmet/batchEditor.py
@@ -86,7 +86,7 @@ class BatchEditor:
 
 if __name__ == '__main__':
     from . import GourmetRecipeManager
-    rg = GourmetRecipeManager.RecGui()
+    rg = GourmetRecipeManager.RecGui.instance()
     be=BatchEditor(rg)
     be.set_values_from_recipe(rg.rd.fetch_one(rg.rd.recipe_table))
     be.dialog.run()

--- a/gourmet/reccard.py
+++ b/gourmet/reccard.py
@@ -3120,7 +3120,7 @@ def getYieldSelection (rec, parent=None):
 
 if __name__ == '__main__':
     from gourmet import GourmetRecipeManager
-    rg = GourmetRecipeManager.RecGui()
+    rg = GourmetRecipeManager.RecGui.instance()
     rc = RecCard(rg,recipe=rg.rd.fetch_one(rg.rd.recipe_table,title='Asparagus Custard Tart'))
     Gtk.main()
 

--- a/gourmet/threadManager.py
+++ b/gourmet/threadManager.py
@@ -34,6 +34,7 @@ from gettext import ngettext
 
 from gi.repository import GObject, Gtk, Pango
 
+
 # _IdleObject etc. based on example John Stowers
 # <john.stowers@gmail.com>
 
@@ -244,9 +245,10 @@ class ThreadManagerGui:
         self.tm = get_thread_manager()
         self.threads = {}
 
-        if not messagebox:
-            from .GourmetRecipeManager import get_application
-            self.messagebox = get_application().messagebox
+        if messagebox is None:
+            # import done here to avoid cycling imports
+            from gourmet.GourmetRecipeManager import RecGui
+            self.messagebox = RecGui.instance().messagebox
         else:
             self.messagebox = messagebox
 

--- a/gourmet/threadManager.py
+++ b/gourmet/threadManager.py
@@ -27,6 +27,7 @@
 #
 import threading
 import time
+from typing import Any
 import webbrowser
 
 from gettext import gettext as _
@@ -354,11 +355,8 @@ class ThreadManagerGui:
         b.show()
         self.to_remove.append(threadbox)
 
-    def thread_stopped (self, thread, threadbox):
-        pb = threadbox.get_content_area().get_children()[0].get_children()[1]
-        txt = pb.get_text()
-        txt += '(' + _('cancelled') + ')'
-        pb.set_text(txt)
+    def thread_stopped(self, thread: Any, threadbox: Gtk.InfoBar):
+        threadbox.hide()
 
     def thread_pause (self, thread, threadbox):
         pb = threadbox.get_content_area().get_children()[0].get_children()[1]


### PR DESCRIPTION
This is the second half of fixing imports from file.  

The import thread now makes use of the `RecGui` instance instead of creating a new object, thus fixing the issue of duplicating windows.

However, upon cancel, the import thread is stopped, but the GUI is not cleared:

![image](https://user-images.githubusercontent.com/2159577/94954426-68f96d00-04e9-11eb-971e-d41ddd93d035.png)

Pausing sometimes works, when the thread is at the right place.