### PR TITLE
Fix Recipe Merger

### DIFF
--- a/gourmet/plugins/duplicate_finder/recipeMerger.ui
+++ b/gourmet/plugins/duplicate_finder/recipeMerger.ui
@@ -21,7 +21,6 @@
   </object>
   <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
-    <property name="extension_events">all</property>
     <property name="default_width">700</property>
     <property name="default_height">650</property>
     <property name="type_hint">dialog</property>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This removes a Gtk.Window property that isn't available in Gtk3.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested by importing several times the same meal master file, and launching the `Find Duplicate Recipes` window, as shown below, and merging recipes that are the same.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2159577/94992210-ab25bb80-0588-11eb-8fa8-2548b2bbe640.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
