### PR TITLE
Allow Gourmet to be run as a Python module

### DIFF
--- a/gourmet/__main__.py
+++ b/gourmet/__main__.py
@@ -1,0 +1,3 @@
+if __name__ == '__main__':
+    from gourmet.GourmetRecipeManager import launch_app
+    launch_app()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows Gourmet to be run as a Python module: `python -m gourmet`. Although mostly a nicety, this gives us greater flexibility in how Gourmet is run, helps ensure any entry-point script doesn't contain any logic (recall the old `bin/gourmet` script that altered the import path, although such a script is now optional since Gourmet can be invoked directly with Python), and allows Gourmet to be used with other tooling. As an example (which specifically motivated this change), it's now trivial to run Gourmet in the pdb debugger: `python -m pdb -m gourmet`

## How Has This Been Tested?
Gourmet runs when invoking `python -m gourmet` and can be run in the debugger by invoking `python -m pdb -m gourmet`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
