### PR TITLE
Add missing dependency to installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,7 +62,7 @@ Install the following packages from `apt`:
 ```sh
 sudo apt-get update
 
-sudo apt-get install --no-install-recommends python3-gi python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev enchant python3-bs4 python3-ebooklib python3-keyring python3-lxml python3-pil python3-cairo python3-enchant python3-gi python3-gtkspellcheck python3-reportlab python3-selenium python3-setuptools python3-sqlalchemy python3-pip python3-toml gir1.2-poppler-0.18
+sudo apt-get install --no-install-recommends python3-gi python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev enchant python3-bs4 python3-ebooklib python3-keyring python3-lxml python3-pil python3-cairo python3-enchant python3-gi python3-gtkspellcheck python3-reportlab python3-selenium python3-setuptools python3-sqlalchemy python3-pip python3-toml gir1.2-poppler-0.18 argcomplete
 ```
 
 Then, install dependencies from the Python repository:


### PR DESCRIPTION
The instructions in `INSTALL.md` are missing `argcomplete` as it is listed in the `requirements.txt`.

## Description
I added the missing `argcomplete` in `INSTALL.md`.

If `argcomplete` is not installed on your system, starting gourmet results in an error:

```
$ gourmet 
Traceback (most recent call last):
  File "/home/jan/.local/bin/gourmet", line 5, in <module>
    from gourmet.GourmetRecipeManager import launch_app
  File "/home/jan/.local/lib/python3.8/site-packages/gourmet/GourmetRecipeManager.py", line 11, in <module>
    from gourmet import (
  File "/home/jan/.local/lib/python3.8/site-packages/gourmet/batchEditor.py", line 3, in <module>
    from . import gglobals
  File "/home/jan/.local/lib/python3.8/site-packages/gourmet/gglobals.py", line 8, in <module>
    from .optionparser import args
  File "/home/jan/.local/lib/python3.8/site-packages/gourmet/optionparser.py", line 2, in <module>
    import argcomplete
ModuleNotFoundError: No module named 'argcomplete'
```
## How Has This Been Tested?
I tried installing gourmet on a fresh Ubuntu 20.04 installation and ran into the error message above. Then I installed the missing dependency by running `python3 -m pip install argcomplete` and tried running gourmet again. This time gourmet started without a problem.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
