### PR TITLE
Fix PDF export for recipes with half-stars or >4 ingredients

### DIFF
--- a/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
+++ b/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
@@ -607,7 +607,7 @@ class PdfExporter (exporter.exporter_mult, PdfWriter):
         # condbreak and a head...
         ings = self.txt[2:]
         if len(ings) > 4:
-            half = (len(ings) / 2)
+            half = len(ings) // 2
             first_half = ings[:-half]
             second_half = ings[-half:]
             t = platypus.Table(

--- a/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
+++ b/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
@@ -95,7 +95,7 @@ class Star (platypus.Flowable):
         inner = False # Start on top
         is_origin = True
         #print 'Drawing star with radius',outer_length,'(moving origin ',origin,')'
-        for theta in range(0,360,360/(points*2)):
+        for theta in range(0, 360, 360 // (points * 2)):
             if 0 < theta < 180: continue
             if inner: r = inner_length
             else: r = outer_length


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes 2 integer divisions, analogous to a previous fix in #230.

## How Has This Been Tested?
I noticed I couldn't export a recipe with a half-star or with long ingredient lists. After this fix, the export was successful.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
