### PR TITLE
Fix unit converter GUI

### DIFF
--- a/gourmet/plugins/unit_converter/converter.ui
+++ b/gourmet/plugins/unit_converter/converter.ui
@@ -303,7 +303,7 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkComboBox" id="itemComboBox">
+                                          <object class="GtkComboBoxText" id="itemComboBox">
                                             <property name="visible">True</property>
                                             <signal handler="itemChanged" last_modification_time="Thu, 16 Sep 2004 23:44:39 GMT" name="changed"/>
                                             <property name="model">model1</property>

--- a/gourmet/tests/dogtail/test_unit_converter.py
+++ b/gourmet/tests/dogtail/test_unit_converter.py
@@ -1,0 +1,51 @@
+from dogtail import procedural
+from dogtail import tree
+from dogtail.utils import run
+
+
+def test_unit_converter():
+    """Dogtail integration test: Unit converter plugin behaves as intended."""
+
+    cmd = "gourmet"
+
+    pid = run(cmd, timeout=3)
+    gourmet = None
+
+    for app in tree.root.applications():
+        if app.get_process_id() == pid:
+            gourmet = app
+            break
+
+    assert gourmet is not None, "Could not find Gourmet instance!"
+
+    # Open the unit converter plugin
+    procedural.keyCombo("<Alt>T")
+    procedural.keyCombo("U")
+    procedural.focus.window("Unit Converter")
+
+    # Enter source amount and unit (5 liters)
+    procedural.keyCombo("<Alt>A")
+    procedural.type("5")
+    procedural.keyCombo("<Alt>U")
+    procedural.keyCombo("<Enter>")
+    procedural.click("liter (l)")
+
+    # Enter target unit (ml)
+    procedural.keyCombo("<Alt>U")
+    procedural.keyCombo("<Enter>")
+    procedural.keyCombo("Right")
+    for _ in range(7):
+        procedural.keyCombo("Down")
+    procedural.keyCombo("<Enter>")
+
+    # Check that the result is shown correctly
+    assert procedural.focus.widget(name="5 l = 5000 ml", roleName="label")
+
+    # There are now two windows, the unit converter, and main window
+    # Close them successively to quit the application
+    procedural.keyCombo("<Alt><F4>")
+    procedural.keyCombo("<Alt><F4>")
+
+
+if __name__ == "__main__":
+    test_unit_converter()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `append_text` method is deprecated for `GtkComboBox`, switch to `GtkComboBoxText`.


## How Has This Been Tested?
I noticed the unit converter plugin did not work properly and a deprecation error was thrown for the `append_text` method in https://github.com/kirienko/gourmet/blob/101d6bbf098dab1289fda123ca35c24ce5b861f0/gourmet/plugins/unit_converter/convertGui.py#L54. This change fixed it.

I also tried to add a dogtail test to exercise the plugin, but I'm not sure if this is the right way to do it.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
