### PR TITLE
Fix switching windows with the 'Go' menu

### DIFF
--- a/src/gourmet/GourmetRecipeManager.py
+++ b/src/gourmet/GourmetRecipeManager.py
@@ -200,7 +200,7 @@ class GourmetApplication:
         separator.show()
         for rc in list(self.rc.values()):
             i=Gtk.MenuItem("_%s"%rc.current_rec.title)
-            i.connect('activate',rc.show)
+            i.connect('activate', lambda *args: rc.show())
             m.append(i)
             i.show()
         return m
@@ -228,8 +228,9 @@ class GourmetApplication:
 
             existing_action = self.goActionGroup.get_action(action_name)
             if not existing_action:
-                self.goActionGroup.add_actions([(action_name, None, title,
-                                                 None, None, rc.show)])
+                self.goActionGroup.add_actions([(
+                    action_name, None, title, None, None, lambda *args: rc.show()
+                )])
             else:
                 existing_action.set_property('label', title)
 


### PR DESCRIPTION
## Description

Start Gourmet, and open a recipe. Then try to switch between the open windows with the 'Go' menu. Switching to a recipe card fails with `TypeError: show() takes 1 positional argument but 2 were given`. This PR fixes that, so you the menu entry works as expected.

The issue is that the signal mechanism is passing an argument, but the `RecCard.show()` method doesn't expect one. The solution, already used elsewhere in the code, is to wrap it in a lambda which discards the argument(s).

## How Has This Been Tested?

Followed the above steps manually.

## Screenshots (if appropriate):

![screenshot showing the Go menu](https://user-images.githubusercontent.com/327925/99877583-2e61a600-2bf7-11eb-8830-25774d0bbf11.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
