### PR TITLE
Fix file chooser dialog on recipe export

### DIFF
--- a/src/gourmet/gtk_extras/dialog_extras.py
+++ b/src/gourmet/gtk_extras/dialog_extras.py
@@ -1086,16 +1086,7 @@ class FileSelectorDialog:
         else:
             self.fsd.set_current_name(stem)
 
-    def is_extension_legal(self, filenames: List[str]) -> bool:
-        if filenames:
-            for extension in self.extensions:
-                if not extension:
-                    extension = ""
-                if fnmatch.fnmatch(filenames[0], extension):
-                    return True
-        return False
-
-    def run(self) -> List[str]:
+    def run(self) -> Optional[List[str]]:
         """Return a list of filenames.
 
         If saving files, the file type is also returned as the last entry in

--- a/src/gourmet/gtk_extras/dialog_extras.py
+++ b/src/gourmet/gtk_extras/dialog_extras.py
@@ -880,7 +880,7 @@ def show_message(*args, **kwargs):
 
 def select_file(title,
                 filename=None,
-                filters=[],
+                filters=None,
                 # filters are lists of a name, a list of mime types and a list of
                 # patterns ['Plain Text', ['text/plain'], '*txt']
                 action=Gtk.FileChooserAction.OPEN,
@@ -889,6 +889,8 @@ def select_file(title,
                 buttons=None,
                 parent=None
                 ):
+    if filters is None:
+        filters = []
     sfd = FileSelectorDialog(title,
                              filename=filename,
                              filters=filters,

--- a/src/gourmet/importers/importManager.py
+++ b/src/gourmet/importers/importManager.py
@@ -127,7 +127,7 @@ class ImportManager (plugin_loader.Pluggable):
                                    filters=self.get_filters(),
                                    parent=parent,
                                    select_multiple=True)
-        if not filenames:
+        if filenames is None:
             return
         self.import_filenames(filenames)
 

--- a/src/gourmet/reccard.py
+++ b/src/gourmet/reccard.py
@@ -1550,12 +1550,10 @@ class ImageBox: # used in DescriptionEditor for recipe image.
         self.draw_image()
 
     def set_from_fileCB(self, widget: Gtk.Button):
-        filenames = de.select_image("Select Image",
+        filename = de.select_image("Select Image",
                                     action=Gtk.FileChooserAction.OPEN)
-        if filenames:
-            fname, *_ = filenames
-            fname = Path(fname)
-            Undo.UndoableObject(lambda *args: self.set_from_file(fname),
+        if filename is not None:
+            Undo.UndoableObject(lambda *args: self.set_from_file(filename),
                                 lambda *args: self.remove_image(),
                                 self.rc.history,
                                 widget=self.imageW).perform()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes #346 where it's described how recipes cannot be exported.  
This was due to a bug in the interface between the file selector window, which returned only a list of filename(s), and the logic later that was expecting an extension to look up the correct plugin.  

Now, the extension is directly provided, looked-up from the filetype combobox in the file chooser dialog.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by:
1) Choosing a filename and a type in the combo box;  
2) Setting a custom extension, but verifying that the type is correctly inferred from the combobox; 
    The combo box gets updated when typing another valid extension.  That is, if `recipe.invalid` is provided,
    then the file type is inferred from the combo box.  
   If the filename is set to `recipe.txt`, then the combo box gets updated automatically, and its value is used, as above.  
3) Not setting a filename greys out the `Ok` button, which simplifies the input validation.  
4) Cancelling an export is correctly handled by returning `None, None` to the export manager.   
5) The same base class is used to import images. Images can correctly be added to a recipe.  

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
