### PR TITLE
Refactor mastercook text file check

### DIFF
--- a/src/gourmet/gtk_extras/dialog_extras.py
+++ b/src/gourmet/gtk_extras/dialog_extras.py
@@ -1,4 +1,3 @@
-import fnmatch
 import os.path
 import re
 import traceback
@@ -22,14 +21,6 @@ Y_PADDING = 12
 
 class UserCancelledError(Exception):
     pass
-
-
-def is_markup(s):
-    try:
-        Pango.parse_markup(s, '0')
-        return True
-    except:
-        return False
 
 
 class ModalDialog (Gtk.Dialog):
@@ -178,8 +169,7 @@ class MessageDialog(Gtk.MessageDialog, ModalDialog):
         self.set_title(title)
 
     def setup_label(self, label: str):
-        if not is_markup(label):
-            label = xml.sax.saxutils.escape(label)
+        label = xml.sax.saxutils.escape(label)
         label = f'<span weight="bold" size="larger">{label}</span>'
         self.set_markup(label)
 

--- a/src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_plaintext_importer.py
+++ b/src/gourmet/plugins/import_export/mastercook_import_plugin/mastercook_plaintext_importer.py
@@ -225,30 +225,26 @@ class MastercookPlaintextImporter(plaintext_importer.TextImporter):
 
 
 class Tester(importer.Tester):
+    """Check whether the given file is a Mastercook export."""
+
     def __init__(self):
+        """Initialize the tester with Mastercook regexps.
+
+        For this type, there is also another check to ensure that unsupported
+        look alike are not accepted.
+        """
         importer.Tester.__init__(self, regexp=MASTERCOOK_START_REGEXP)
         self.not_me = "<[?]?(xml|mx2|RcpE|RTxt)[^>]*>"
 
-    def test(self, filename):
+    def test(self, filename: str) -> bool:
+        """Test that the provided file is a Mastercook file."""
         if not hasattr(self, 'matcher'):
             self.matcher = re.compile(self.regexp)
             self.not_matcher = re.compile(self.not_me)
-        if isinstance(filename, str):
-            self.ofi = open(filename, 'r')
-            CLOSE = True
-        else:
-            self.ofi = filename
-            CLOSE = False
-        l = self.ofi.readline()
-        while l:
-            if self.not_matcher.match(l):
-                self.ofi.close()
-                return False
-            if self.matcher.match(l):
-                self.ofi.close()
-                return True
-            l = self.ofi.readline()
-        if CLOSE:
-            self.ofi.close()
-        else:
-            self.ofi.seek(0)
+
+        with open(filename) as fin:
+            for line in fin.readlines():
+                if self.not_matcher.match(line):
+                    return False
+                if self.matcher.match(line):
+                    return True

--- a/tests/recipe_files/mastercook_text_export.mxp
+++ b/tests/recipe_files/mastercook_text_export.mxp
@@ -1,0 +1,27 @@
+                     *  Exported from  MasterCook  *
+
+                               4th Of July
+
+Recipe By     : 
+Serving Size  : 1    Preparation Time :0:00
+Categories    : Mixed Drinks                     Specialty Drinks
+
+  Amount  Measure       Ingredient -- Preparation Method
+--------  ------------  --------------------------------
+   1 1/2  ounces        Vodka
+     1/2  ounce         Triple sec
+     1/2  ounce         Sweet and sour mix
+     1/2  ounce         Curacao
+   1      dash          Grenadine
+
+   Mix all ingredients except grenadine in shaker and chill.  Serve in martini glass.  Add grenadine and it will sink to bottom. This is a great specialty drink for Independance Day.
+
+   Recipe Source:
+THE ALL DRINKS LIST  compiled by Andy Premaza
+<http://cutter.ship.edu/~ap4269/alldrink.html>
+
+  Formatted for MasterCook by Joe Comiskey, aka MR MAD  -  jpmd44a@prodigy.com   -or-   MAD-SQUAD@prodigy.net
+
+     06-17-1998
+
+                   - - - - - - - - - - - - - - - - - - 

--- a/tests/test_imports_from_files.py
+++ b/tests/test_imports_from_files.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 
 from gourmet.importers.importManager import ImportFileList, ImportManager
+from gourmet.plugins.import_export.mastercook_import_plugin.mastercook_plaintext_importer import Tester as MCTester  # noqa
 from gourmet.recipeManager import RecipeManager
 
 TEST_FILE_DIRECTORY = Path(__file__).parent / 'recipe_files'
@@ -153,3 +154,9 @@ def test_mycookbook():
                      'link': 'https://www.allrecipes.com/recipe/10549/best-brownies/',  # noqa
                     }
                  })
+
+
+def test_mastercook_file_tester():
+    filename = TEST_FILE_DIRECTORY / 'mastercook_text_export.mxp'
+    tester = MCTester()
+    assert tester.test(filename)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR refactors the Mastercook text file check: some code was unreachable, and the argument is always a filepath string.  
It can therefore all be done in a context manager.  

Some dead code from `gtk_extras` was also removed: `is_markup` always returns `False` because an exception is raised.  
This is due to an API change in Gtk3, but the check is insignificant enough that it can be removed altogether, rather than fixed.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The Mastercook check refactor was tested by adding an integration test.  

The `is_markup` removal was tested by running the application and creating dialogs: editing a recipe and closing it before save, prompting a dialog.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor!

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
