### PR TITLE
Improve ImageBrowserDialog

### DIFF
--- a/src/gourmet/image_utils.py
+++ b/src/gourmet/image_utils.py
@@ -133,9 +133,21 @@ class ImageBrowser(Gtk.Dialog):
 
         self.image: Optional[Image.Image] = None
         self.liststore = Gtk.ListStore(GdkPixbuf.Pixbuf)
+
         iconview = Gtk.IconView.new()
         iconview.set_model(self.liststore)
         iconview.set_pixbuf_column(0)
+        iconview.connect('selection-changed', self.on_selection)
+
+        scrollable = Gtk.ScrolledWindow()
+        scrollable.set_vexpand(True)
+        scrollable.add(iconview)
+
+        box = self.get_content_area()
+        box.pack_end(scrollable, True, True, 0)
+        self.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                         Gtk.STOCK_OK, Gtk.ResponseType.OK)
+        self.show_all()
 
         self._stop_retrieval = Event()
         self._image_retrieve_task = Thread(target=self._load_uris, args=[uris])
@@ -150,14 +162,6 @@ class ImageBrowser(Gtk.Dialog):
                 continue
             pixbuf = bytes_to_pixbuf(image_to_bytes(image))
             self.liststore.append([pixbuf])
-
-        iconview.connect('selection-changed', self.on_selection)
-
-        box = self.get_content_area()
-        box.pack_end(iconview, True, True, 0)
-        self.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                         Gtk.STOCK_OK, Gtk.ResponseType.OK)
-        self.show_all()
 
     def on_selection(self, iconview: Gtk.IconView):
         item = iconview.get_selected_items()

--- a/src/gourmet/importers/interactive_importer.py
+++ b/src/gourmet/importers/interactive_importer.py
@@ -461,13 +461,13 @@ class InteractiveImporter (ConvenientImporter, NotThreadSafe):
             for rec in self.added_recs:
                 browser = ImageBrowser(self.w, self.images)
                 response = browser.run()
+                browser.destroy()
                 if response == Gtk.ResponseType.OK:
                     thumb = browser.image.copy()
                     thumb.thumbnail((40, 40))
                     self.rd.modify_rec(rec,
                                        {'image': image_to_bytes(browser.image),
                                         'thumb': image_to_bytes(thumb)})
-                browser.destroy()
 
         if self.modal:
             self.w.hide()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR improves `gourmet.image_utils.ImageBrowser` by making the image retrieval a background thread, thus not blocking until all images are retrieved, and making the dialog scrollable.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by importing a web recipe.

## Screenshots (if appropriate):
The dialog used to expand each time an image was added, often making the dialog expand beyond the screen:  
![expanded_image_browser](https://user-images.githubusercontent.com/2159577/123548874-ee533a80-d766-11eb-8dec-8532186ac12b.png)

It now retains its size:  
![scrolled_image_browser](https://user-images.githubusercontent.com/2159577/123548735-57867e00-d766-11eb-9996-81f4dde01771.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
