### PR TITLE
Create ImageBox.thumbnail when ImageBox.image is being set

### DIFF
--- a/src/gourmet/reccard.py
+++ b/src/gourmet/reccard.py
@@ -1472,6 +1472,7 @@ class ImageBox:
         self.addW = self.ui.get_object('addImage')
         self.delW = self.ui.get_object('delImageButton')
         self.image: Image.Image = None
+        self.thumbnail: Image.Image = None
 
     def get_image(self, rec: Optional['RowProxy'] = None):
         """Set image based on current recipe."""
@@ -1513,7 +1514,7 @@ class ImageBox:
         debug("commit (self):", 5)
         if self.image:
             self.imageW.show()
-            return iu.image_to_bytes(self.image), iu.image_to_bytes(self.thumb)
+            return iu.image_to_bytes(self.image), iu.image_to_bytes(self.thumbnail)
         else:
             self.imageW.hide()
             return None, None
@@ -1533,8 +1534,6 @@ class ImageBox:
             size = (100, 100)
 
         self.image.thumbnail(size)
-        self.thumb = self.image.copy()
-        self.thumb.thumbnail((40, 40))
         self.set_from_bytes(iu.image_to_bytes(self.image))
 
     def show_image (self):
@@ -1552,6 +1551,8 @@ class ImageBox:
         self.orig_pixbuf = pb
 
         self.image = iu.bytes_to_image(bytes_)
+        self.thumbnail = self.image.copy()
+        self.thumbnail.thumbnail((40, 40))
 
         self.show_image()
         self.edited = True

--- a/src/gourmet/reccard.py
+++ b/src/gourmet/reccard.py
@@ -3,7 +3,7 @@ import os.path
 import webbrowser
 import xml.sax.saxutils
 from pkgutil import get_data
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from gi.repository import Gdk, GdkPixbuf, GLib, GObject, Gtk, Pango
 from PIL import Image
@@ -1459,13 +1459,15 @@ class DescriptionEditorModule (TextEditor, RecEditorModule):
         self.emit('saved')
         return recdic
 
-class ImageBox: # used in DescriptionEditor for recipe image.
-    def __init__ (self, RecCard):
+
+class ImageBox:
+    """A widget for handling images in the DescriptionEditor."""
+    def __init__(self, rec_card):
         debug("__init__ (self, RecCard):",5)
         self.edited = False
-        self.rg = RecCard.rg
-        self.rc = RecCard
-        self.ui = self.rc.ui
+        self.rc = rec_card
+        self.rg = rec_card.rg
+        self.ui = rec_card.ui
         self.imageW = self.ui.get_object('recImage')
         self.addW = self.ui.get_object('addImage')
         self.delW = self.ui.get_object('delImageButton')
@@ -1506,7 +1508,7 @@ class ImageBox: # used in DescriptionEditor for recipe image.
         self.addW.show()
         return True
 
-    def commit(self) -> Optional[Tuple[bytes, bytes]]:
+    def commit(self) -> Union[Tuple[bytes, bytes], Tuple[None, None]]:
         """Return image and thumbnail data for storage in the database."""
         debug("commit (self):", 5)
         if self.image:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->  
This closes #357 , in which it's described how a recipe cannot be modified, because of a save error when serializing the image and its thumbnail.  
The problem is that the thumbnail attribute was only created when loading an image from file, and not when loading the image from bytes (ie. from the database.)  
This resolves the issue by moving the thumbnail creation to whenever the image is loaded.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by editing the title of a recipe (`Hong Kong ice cream` -> `Hong-Kong ice cream`).  
Without the changes, an AttributeError is raised.  
With the changes, the application behaves as expected. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
