### PR TITLE
Fix pdf export when locale is set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         run: sudo pip3 install -r development.in
 
       - name: Test with pytest
-        run: xvfb-run -a pytest -vv tests/test_*
+        run: LANGUAGE=de_DE.utf-8 xvfb-run -a pytest -vv tests/test_*
 
       - name: Check imports ordering
         run: >

--- a/src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
+++ b/src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
@@ -870,8 +870,6 @@ class PdfPrefGetter:
     OPT_PS,OPT_PO,OPT_FS,OPT_PL,OPT_LM,OPT_RM,OPT_TM,OPT_BM = list(range(8))
 
     def __init__(self):
-        self.prefs = Prefs.instance()
-        defaults = self.prefs.get('PDF_EXP', PDF_PREF_DEFAULT)
         self.size_strings = list(self.page_sizes.keys())
         self.size_strings.sort()
         for n in range(2,5):
@@ -879,10 +877,12 @@ class PdfPrefGetter:
         self.make_reverse_dicts()
         self.layout_strings = list(self.layouts.keys())
         self.layout_strings.sort()
-        margin_widgets = [
-            CustomUnitOption(defaults.get(pref,PDF_PREF_DEFAULT[pref]))
-            for pref in ['left_margin','right_margin','top_margin','bottom_margin']
-            ]
+
+        defaults = Prefs.instance().get('PDF_EXP', PDF_PREF_DEFAULT)
+
+        margin_widgets = [CustomUnitOption(defaults.get(pref, PDF_PREF_DEFAULT[pref]))
+                          for pref in ['left_margin', 'right_margin', 'top_margin', 'bottom_margin']
+                          ]
         # Make unit changes to one widget affect all the others!
         for m in margin_widgets:
             for mm in margin_widgets:
@@ -955,7 +955,7 @@ class PdfPrefGetter:
         system values, they are also saved to the persistent preferences.
         """
         args = {}
-        prefs = self.prefs.get('PDF_EXP', {})
+        prefs = Prefs.instance().get('PDF_EXP', {})
         args['pagesize'] = self.page_sizes[opts[self.OPT_PS][1]]
         prefs['page_size'] = args['pagesize']
 

--- a/src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
+++ b/src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
@@ -721,14 +721,14 @@ class PdfPageDrawer (PageDrawer):
         self.set_page_area(size[0],size[1],areas)
 
 PDF_PREF_DEFAULT={
-    'page_size':_('Letter'),
-    'orientation':_('Portrait'),
-    'font_size':10,
-    'page_layout':_('Plain'),
-    'left_margin':1.0*inch,
-    'right_margin':1.0*inch,
-    'top_margin':1.0*inch,
-    'bottom_margin':1.0*inch,
+    'page_size': 'letter',
+    'orientation': 'portrait',
+    'font_size': 10,
+    'page_layout': 'plain',
+    'left_margin': 1.0 * inch,
+    'right_margin': 1.0 * inch,
+    'top_margin': 1.0 * inch,
+    'bottom_margin': 1.0 * inch,
     }
 
 class CustomUnitOption (optionTable.CustomOption):
@@ -832,28 +832,40 @@ class CustomUnitOption (optionTable.CustomOption):
 
 class PdfPrefGetter:
     page_sizes = {
-        _('11x17"'):'elevenSeventeen',
-        _('Index Card (3.5x5")'):(3.5*inch,5*inch),
-        _('Index Card (4x6")'):(4*inch,6*inch),
-        _('Index Card (5x8")'):(5*inch,8*inch),
-        _('Index Card (A7)'):(74*mm,105*mm),
-        _('Letter'):'letter',
-        _('Legal'):'legal',
-        'A0':'A0','A1':'A1','A2':'A2','A3':'A3','A4':'A4','A5':'A5','A6':'A6',
-        'B0':'B0','B1':'B1','B2':'B2','B3':'B3','B4':'B4','B5':'B5','B6':'B6',
+        _('11x17"'): 'elevenSeventeen',
+        _('Index Card (3.5x5")'): (3.5 * inch, 5 * inch),
+        _('Index Card (4x6")'): (4 * inch, 6 * inch),
+        _('Index Card (5x8")'): (5 * inch, 8 * inch),
+        _('Index Card (A7)'): (74 * mm, 105 * mm),
+        _('Letter'): 'letter',
+        _('Legal'): 'legal',
+        'A0': 'A0',
+        'A1': 'A1',
+        'A2': 'A2',
+        'A3': 'A3',
+        'A4': 'A4',
+        'A5': 'A5',
+        'A6': 'A6',
+        'B0': 'B0',
+        'B1': 'B1',
+        'B2': 'B2',
+        'B3': 'B3',
+        'B4': 'B4',
+        'B5': 'B5',
+        'B6': 'B6',
         }
 
-    INDEX_CARDS = [(3.5*inch, 5*inch),
-                   (4*inch, 6*inch),
-                   (5*inch, 8*inch),
-                   (74*mm, 105*mm)]
+    INDEX_CARDS = [(3.5 * inch, 5 * inch),
+                   (4 * inch, 6 * inch),
+                   (5 * inch, 8 * inch),
+                   (74 * mm, 105 * mm)]
     INDEX_CARD_LAYOUTS = [_('Index Cards (3.5x5)'),
                           _('Index Cards (4x6)'),
                           _('Index Cards (A7)')]
     layouts = {_('Plain'): ('column', 1),
-               _('Index Cards (3.5x5)'): ('index_cards', (5*inch, 3.5*inch)),
-               _('Index Cards (4x6)'): ('index_cards', (6*inch, 4*inch)),
-               _('Index Cards (A7)'): ('index_cards', (105*mm, 74*mm))}
+               _('Index Cards (3.5x5)'): ('index_cards', (5 * inch, 3.5 * inch)),
+               _('Index Cards (4x6)'): ('index_cards', (6 * inch, 4 * inch)),
+               _('Index Cards (A7)'): ('index_cards', (105 * mm, 74 * mm))}
 
     # These two dictionaries are here to be able to store the preferences in the persistent toml file.
     # This allows us to have a locale-agnostic GUI.
@@ -867,7 +879,7 @@ class PdfPrefGetter:
     page_modes = {_('Portrait'): 'portrait',
                   _('Landscape'): 'landscape'}
 
-    OPT_PS,OPT_PO,OPT_FS,OPT_PL,OPT_LM,OPT_RM,OPT_TM,OPT_BM = list(range(8))
+    OPT_PS, OPT_PO, OPT_FS, OPT_PL, OPT_LM, OPT_RM, OPT_TM, OPT_BM = list(range(8))
 
     def __init__(self):
         self.size_strings = list(self.page_sizes.keys())
@@ -970,7 +982,7 @@ class PdfPrefGetter:
         prefs['bottom_margin'] = args['bottom_margin'] = opts[self.OPT_BM][1]
         return args
 
-    def change_cb (self, option_table, *args,**kwargs):
+    def change_cb(self, option_table, *args,**kwargs):
         if self.in_ccb: return
         self.in_ccb = True
         option_table.apply()

--- a/src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
+++ b/src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
@@ -874,7 +874,11 @@ class PdfPrefGetter:
         self.size_strings.sort()
         for n in range(2,5):
             self.layouts[ngettext('%s Column','%s Columns',n)%n]=('column',n)
-        self.make_reverse_dicts()
+
+        self.page_sizes_r = {v: k for k, v in self.page_sizes.items()}
+        self.layouts_r = {v: k for k, v in self.layouts.items()}
+        self.page_modes_r = {v: k for k, v in self.page_modes.items()}
+
         self.layout_strings = list(self.layouts.keys())
         self.layout_strings.sort()
 
@@ -927,14 +931,6 @@ class PdfPrefGetter:
         self.table.emit('changed')
         self.page_drawer.set_size_request(200,100)
         self.page_drawer.show()
-
-    def make_reverse_dicts (self):
-        self.page_sizes_r = {}; self.layouts_r = {}; self.page_modes_r = {}
-        for dict,dict_r in [
-            (self.page_sizes,self.page_sizes_r),
-            (self.layouts,self.layouts_r),
-            (self.page_modes,self.page_modes_r)]:
-            for k,v in list(dict.items()): dict_r[v]=k
 
     def setup_widgets (self):
         self.pd = de.PreferencesDialog(self.opts,option_label=None,value_label=None,

--- a/src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
+++ b/src/gourmet/plugins/import_export/pdf_plugin/pdf_exporter.py
@@ -1,28 +1,18 @@
 import math
 import os.path
-import re
 import tempfile
-import types
-import webbrowser
 import xml.sax.saxutils
 from gettext import ngettext
 from io import BytesIO
+from typing import List, Optional, Tuple, Union
 
-import reportlab
-import reportlab.lib.colors as colors
-import reportlab.lib.fonts as fonts
-import reportlab.lib.pagesizes as pagesizes
-import reportlab.lib.styles as styles
-import reportlab.lib.units as units
-import reportlab.platypus as platypus
 from gi.repository import Gtk
+from reportlab import platypus
+from reportlab.lib import colors, pagesizes, styles
 from reportlab.lib.units import inch, mm
-from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfgen import canvas
-from reportlab.platypus.flowables import ParagraphAndImage
 
 import gourmet.exporters.exporter as exporter
-from gourmet import convert, gglobals, image_utils
+from gourmet import convert, gglobals
 from gourmet.gtk_extras import cb_extras
 from gourmet.gtk_extras import dialog_extras as de
 from gourmet.gtk_extras import optionTable
@@ -31,7 +21,16 @@ from gourmet.prefs import Prefs
 
 from .page_drawer import PageDrawer
 
-DEFAULT_PDF_ARGS = {'bottom_margin': 72, 'pagesize': 'letter', 'right_margin': 72, 'top_margin': 72, 'left_margin': 72, 'pagemode': 'portrait', 'base_font_size': 10, 'mode': ('column', 1)}
+DEFAULT_PDF_ARGS = {
+    'bottom_margin': 72,
+    'pagesize': 'letter',
+    'right_margin': 72,
+    'top_margin': 72,
+    'left_margin': 72,
+    'pagemode': 'portrait',
+    'base_font_size': 10,
+    'mode': ('column', 1)
+}
 
 # Code for MCLine from:
 # http://two.pairlist.net/pipermail/reportlab-users/2005-February/003695.html
@@ -217,7 +216,7 @@ class Bookmark(platypus.Flowable):
 
 class PdfWriter:
 
-    def __init__ (self, allrecs=[]):
+    def __init__ (self, allrecs=None):
         pass
 
     def setup_document (self, file, mode=('column',1), size='default', pagesize='letter',
@@ -226,9 +225,9 @@ class PdfWriter:
                         bottom_margin=inch,
                         base_font_size=10
                         ):
-        frames = self.setup_frames(mode,size,pagesize,pagemode,
-                                   left_margin,right_margin,top_margin,
-                                   bottom_margin,base_font_size)
+        frames = self.setup_frames(mode, size,pagesize, pagemode,
+                                   left_margin, right_margin, top_margin,
+                                   bottom_margin, base_font_size)
         pt = platypus.PageTemplate(frames=frames)
         self.doc = platypus.BaseDocTemplate(file,pagesize=self.pagesize,
                                             pageTemplates=[pt],)
@@ -240,24 +239,34 @@ class PdfWriter:
             self.scale_stylesheet(perc_scale)
         self.txt = []
 
-    def setup_frames (self,mode=('column',1), size='default', pagesize='letter',
-                        pagemode='portrait',left_margin=inch,right_margin=inch,
-                        top_margin=inch,
-                        bottom_margin=inch,
-                        base_font_size=10):
-        if not isinstance(mode, tuple):
-            raise Exception("What is this mode! %s" % str(mode))
+    def setup_frames(self,
+                     mode: Optional[Tuple[str, int]] = None,
+                     size: str = 'default',
+                     pagesize: Union[str, Tuple] = 'LETTER',
+                     pagemode: str = 'portrait',
+                     left_margin: float = inch,
+                     right_margin: float = inch,
+                     top_margin: float = inch,
+                     bottom_margin: float = inch,
+                     base_font_size: Optional[int] = 10) -> List['Frame']:
         if isinstance(pagesize, str):
-            self.pagesize = getattr(pagesizes,pagemode)(getattr(pagesizes,pagesize))
+            pagesize = getattr(pagesizes, pagesize)
+
+        self.pagesize = getattr(pagesizes, pagemode)(pagesize)
+        self.margins = (left_margin, right_margin, top_margin, bottom_margin)
+
+        if mode is not None:
+            mode, count = mode
         else:
-            self.pagesize = getattr(pagesizes,pagemode)(pagesize)
-        self.margins = (left_margin,right_margin,top_margin,bottom_margin)
-        if mode[0] == 'column':
-            frames = self.setup_column_frames(mode[1])
-        elif mode[0] == 'index_cards':
-            frames = self.setup_multiple_index_cards(mode[1])
+            mode, count = 'column', 1
+
+        if mode == 'column':
+            frames = self.setup_column_frames(count)
+        elif mode == 'index_cards':
+            frames = self.setup_multiple_index_cards(count)
         else:
-            raise Exception("WTF - mode = %s" % str(mode))
+            raise ValueError(f'Expected mode to be "column" or "index_cards" '
+                             f'not {mode}')
         return frames
 
     def scale_stylesheet (self, perc):
@@ -400,10 +409,13 @@ class PdfExporter (exporter.exporter_mult, PdfWriter):
     def __init__ (self, rd, r, out,
                   doc=None,
                   styleSheet=None,
-                  txt=[],
-                  pdf_args=DEFAULT_PDF_ARGS,
-                  all_recipes=[], # For learning about references...
+                  txt=None,
+                  pdf_args=None,
+                  all_recipes=None,  # For learning about references...
                   **kwargs):
+        txt = txt if txt is not None else []
+        pdf_args = pdf_args if pdf_args is not None else DEFAULT_PDF_ARGS
+        all_recipes = all_recipes if all_recipes is not None else []
         self.all_recipes = all_recipes
         PdfWriter.__init__(self)
         if isinstance(out, str):
@@ -682,11 +694,11 @@ class PdfExporterMultiDoc (exporter.ExporterMultirec, PdfWriter):
         self.close()
         self.output_file.close()
 
-class Sizer (PdfWriter):
 
-    def get_size (self, *args, **kwargs):
+class Sizer(PdfWriter):
+    def get_size(self, *args, **kwargs):
         frames = self.setup_frames(*args,**kwargs)
-        return self.pagesize,frames
+        return self.pagesize, frames
 
     def get_pagesize_and_frames_for_widget (self, *args, **kwargs):
         ps,ff = self.get_size(*args,**kwargs)
@@ -830,22 +842,20 @@ class PdfPrefGetter:
         'B0':'B0','B1':'B1','B2':'B2','B3':'B3','B4':'B4','B5':'B5','B6':'B6',
         }
 
-    INDEX_CARDS = [(3.5*inch,5*inch),(4*inch,6*inch),(5*inch,8*inch),(74*mm,105*mm)]
+    INDEX_CARDS = [(3.5*inch, 5*inch),
+                   (4*inch, 6*inch),
+                   (5*inch, 8*inch),
+                   (74*mm, 105*mm)]
     INDEX_CARD_LAYOUTS = [_('Index Cards (3.5x5)'),
                           _('Index Cards (4x6)'),
-                          _('Index Cards (A7)'),
-                          ]
-    layouts = {
-        _('Plain'):('column',1),
-        _('Index Cards (3.5x5)'):('index_cards',(5*inch,3.5*inch)),
-        _('Index Cards (4x6)'):('index_cards',(6*inch,4*inch)),
-        _('Index Cards (A7)'):('index_cards',(105*mm,74*mm)),
-        }
+                          _('Index Cards (A7)')]
+    layouts = {_('Plain'): ('column', 1),
+               _('Index Cards (3.5x5)'): ('index_cards', (5*inch, 3.5*inch)),
+               _('Index Cards (4x6)'): ('index_cards', (6*inch, 4*inch)),
+               _('Index Cards (A7)'): ('index_cards', (105*mm, 74*mm))}
 
-    page_modes = {
-        _('Portrait'):'portrait',
-        _('Landscape'):'landscape',
-        }
+    page_modes = {_('Portrait'): 'portrait',
+                  _('Landscape'): 'landscape'}
 
     OPT_PS,OPT_PO,OPT_FS,OPT_PL,OPT_LM,OPT_RM,OPT_TM,OPT_BM = list(range(8))
 
@@ -911,15 +921,23 @@ class PdfPrefGetter:
         self.pd.run()
         return self.get_args_from_opts(self.opts)
 
-    def get_args_from_opts (self, opts):
+    def get_args_from_opts(self, opts):
         args = {}
         prefs = self.prefs.get('PDF_EXP', {})
-        args['pagesize'] = self.page_sizes[opts[self.OPT_PS][1]] # PAGE SIZE
+        args['pagesize'] = self.page_sizes[opts[self.OPT_PS][1]]
         prefs['page_size'] = self.page_sizes_r[args['pagesize']]
-        args['pagemode'] = self.page_modes[opts[self.OPT_PO][1]] # PAGE MODE
+
+        try:
+            mode = self.page_modes[opts[self.OPT_PO][-1]]
+        except KeyError:  # the value was not set in the export dialog
+            mode = list(self.page_modes.items())[0][-1]
+        args['pagemode'] = mode
+
         prefs['orientation'] = self.page_modes_r[args['pagemode']]
-        prefs['font_size'] = args['base_font_size'] = opts[self.OPT_FS][1] # FONT SIZE
-        args['mode'] = self.layouts[opts[self.OPT_PL][1]] # LAYOUT/MODE
+
+        prefs['font_size'] = args['base_font_size'] = opts[self.OPT_FS][1]
+
+        args['mode'] = self.layouts[opts[self.OPT_PL][1]]
         prefs['page_layout'] = self.layouts_r[args['mode']]
         prefs['left_margin'] = args['left_margin'] = opts[self.OPT_LM][1]
         prefs['right_margin'] = args['right_margin'] = opts[self.OPT_RM][1]
@@ -1046,8 +1064,9 @@ if __name__ == '__main__':
     Gtk.main()
     raise Exception("Hell")
 
-    from tempfile import tempdir
     import os.path
+    from tempfile import tempdir
+
     #opts = get_pdf_prefs(); print opts
     test_3_x_5()
 

--- a/src/gourmet/plugins/nutritional_information/nutrition.py
+++ b/src/gourmet/plugins/nutritional_information/nutrition.py
@@ -71,7 +71,7 @@ class NutritionData:
         else:
             self.db.do_add(self.db.nutritionconversions_table,{'ingkey':key,'unit':unit,'factor':factor})
 
-    def get_matches (self, key, max=50):
+    def get_matches(self, key, max=50):
         """Handed a string, get a list of likely USDA database matches.
 
         We return a list of lists:

--- a/src/gourmet/reccard.py
+++ b/src/gourmet/reccard.py
@@ -33,19 +33,19 @@ from gourmet.plugin import (IngredientControllerPlugin, RecDisplayPlugin,
 from gourmet.plugins.clipboard_exporter import ClipboardExporter
 from gourmet.recindex import RecIndex
 
-from .image_utils import load_pixbuf_from_resource
 
-
-def find_entry(w) -> Optional[Gtk.Entry]:
-    if isinstance(w, Gtk.Entry):
-        return w
+def find_entry(widget) -> Optional[Gtk.Entry]:
+    """Recurse through all the children widgets to find the first Gtk.Entry."""
+    if isinstance(widget, Gtk.Entry):
+        return widget
     else:
-        if not hasattr(w,'get_children'):
+        if not hasattr(widget, 'get_children'):
             return
-        for child in w.get_children():
+        for child in widget.get_children():
             e = find_entry(child)
             if e is not None:
                 return e
+
 
 class RecRef:
     def __init__ (self, refid, title):
@@ -369,7 +369,7 @@ class RecCardDisplay (plugin_loader.Pluggable):
     # Main GUI setup
     def setup_main_window (self):
         self.window = Gtk.Window()
-        self.window.set_icon(load_pixbuf_from_resource('reccard.png'))
+        self.window.set_icon(iu.load_pixbuf_from_resource('reccard.png'))
         self.window.connect('delete-event',self.hide)
         self.conf.append(WidgetSaver.WindowSaver(self.window,
                                                  self.prefs.get('reccard_window_%s'%self.current_rec.id,
@@ -960,7 +960,7 @@ class RecEditor(WidgetSaver.WidgetPrefs, plugin_loader.Pluggable):
 
     def setup_main_interface (self):
         self.window = Gtk.Window()
-        self.window.set_icon(load_pixbuf_from_resource('reccard_edit.png'))
+        self.window.set_icon(iu.load_pixbuf_from_resource('reccard_edit.png'))
         title = ((self.current_rec and self.current_rec.title) or _('New Recipe')) + ' (%s)'%_('Edit')
         self.window.set_title(title)
         self.window.connect('delete-event',

--- a/tests/test_pdf_exporter.py
+++ b/tests/test_pdf_exporter.py
@@ -1,0 +1,32 @@
+"""This test may leave marks in the user preferences file."""
+import os
+os.environ['LANGUAGE'] = 'de_DE.utf-8'  # must happend before Gourmet import
+
+from gourmet.gglobals import gourmetdir
+from gourmet.plugins.import_export.pdf_plugin.pdf_exporter import PdfPrefGetter  # noqa: import not at top of file
+
+def test_get_args_from_opts(tmp_path):
+    gourmetdir = tmp_path
+    pref_getter = PdfPrefGetter()
+
+    options = (['Papiergröße:', 'Letter'],
+               ['_Ausrichtung:', 'Hochformat'],
+               ['_Schriftgröße:', 10],
+               ['Seiten-Layout', 'Eben'],
+               ['Linker Rand:', 70.86614173228347],
+               ['Rechter Rand:', 70.86614173228347],
+               ['Oberer Rand:', 70.86614173228347],
+               ['Unterer Rand:', 70.86614173228347])
+
+    expected = {'pagesize': 'letter',
+				'pagemode': 'portrait',
+				'base_font_size': 10,
+				'mode': ('column', 1),
+				'left_margin': 70.86614173228347,
+				'right_margin': 70.86614173228347,
+				'top_margin': 70.86614173228347,
+				'bottom_margin': 70.86614173228347} 
+
+    ret = pref_getter.get_args_from_opts(options)
+
+    assert ret == expected


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #362: there was an issue where the window for offering PDF export options weren't correctly set when switching from one locale to the other.  
This was because of the preferences are saved with the option in a locale, but fail to load when another locale is used.  

One way to fix this is to validate the values loaded from the preferences.toml file before using them, but this issue occurs not often enough to warrant such a complicated solution.  
Thus, the values are now stored in english, and looked up in whatever locale is now used.  

This also solve the problem, where we now have fixed locale handling, and people might now be using the application in their respective locales.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This was tested by exporting one or several recipe(s) with `LANGUAGES` set to `de_DE.utf-8`, `fr_FR.utf-8`, and `ru_RU.utf-8`.  
Off this, a minimal unit test was created.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
